### PR TITLE
CCE-48 Wrap E&E exceptions more generically

### DIFF
--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/SoapEligibilityAndEnrollmentClient.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/SoapEligibilityAndEnrollmentClient.java
@@ -61,7 +61,7 @@ public class SoapEligibilityAndEnrollmentClient implements EligibilityAndEnrollm
                   .eeRequestName(eeRequestName)
                   .build()),
           GetEESummaryResponse.class);
-    } catch (Eligibilities.RequestFailed e) {
+    } catch (Exception e) {
       if (StringUtils.containsIgnoreCase(e.getMessage(), "getEESummaryResponse is Missing")) {
         throw new Exceptions.UnknownPatientIcnException(patientIcn, e);
       } else {


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/CCE-48

Wrap any exception from queen-elizabeth/E&E as a `EeUnavailableException`, not just `Eligibilities.RequestFailed`.