### PR TITLE
Added a check for leading http(s) in regression & smoke tests

### DIFF
--- a/community-care-eligibility/src/main/docker/entrypoint.sh
+++ b/community-care-eligibility/src/main/docker/entrypoint.sh
@@ -72,7 +72,7 @@ smokeTest() {
   if [[ ! "$ENDPOINT_DOMAIN_NAME" == http* ]]; then
     ENDPOINT_DOMAIN_NAME="https://$ENDPOINT_DOMAIN_NAME"
   fi
-  
+
   for path in "${PATHS[@]}"
     do
       doCurl 200
@@ -149,10 +149,6 @@ regressionTest() {
 
   path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&patient=$PATIENT"
   doCurl 500 $TOKEN
-
-  # Unknown ICN
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=UNKNOWN"
-  doCurl 404 $TOKEN
 
   printResults
 }

--- a/community-care-eligibility/src/main/docker/entrypoint.sh
+++ b/community-care-eligibility/src/main/docker/entrypoint.sh
@@ -69,6 +69,10 @@ doCurl () {
 
 smokeTest() {
 
+  if [[ ! "$ENDPOINT_DOMAIN_NAME" == http* ]]; then
+    ENDPOINT_DOMAIN_NAME="https://$ENDPOINT_DOMAIN_NAME"
+  fi
+  
   for path in "${PATHS[@]}"
     do
       doCurl 200
@@ -97,6 +101,10 @@ smokeTest() {
 }
 
 regressionTest() {
+
+  if [[ ! "$ENDPOINT_DOMAIN_NAME" == http* ]]; then
+    ENDPOINT_DOMAIN_NAME="https://$ENDPOINT_DOMAIN_NAME"
+  fi
 
   for path in "${PATHS[@]}"
     do


### PR DESCRIPTION
JIRA Issue: https://vasdvp.atlassian.net/browse/CCE-87

Running into timeouts when making calls as part of the deployer release.  The `ENDPOINT_DOMAIN_NAME` was not supplied with a leading http/https.

Updated to handle that scenario similar to Urgent Care. 