### PR TITLE
CCE-108 Removed address param from CCE API call, retrieved from E&E

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ facilities that satisfy the access standards.
 Sample request:
 
 ```
-https://foo.com/community-care/v0/eligibility/search?patient=011235813V213455&street=742%20Evergreen%20Terrace&city=Springfield&state=KY&zip=89144&serviceType=primarycare
+https://foo.com/community-care/v0/eligibility/search?patient=011235813V213455&serviceType=primarycare
 ```
 
 Sample response:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For details about building and running this application, see the [developer guid
 
 ----
 
-The API supports a search query that accepts a patient ICN, the patient's home address,
+The API supports a search query that accepts a patient ICN
 and the patient's desired medical service type.
 
 The medical service type is one of:

--- a/community-care-eligibility-api/src/main/java/gov/va/api/health/communitycareeligibility/api/CommunityCareEligibilityResponse.java
+++ b/community-care-eligibility-api/src/main/java/gov/va/api/health/communitycareeligibility/api/CommunityCareEligibilityResponse.java
@@ -23,13 +23,13 @@ public final class CommunityCareEligibilityResponse {
 
   PatientRequest patientRequest;
 
-  Address patientAddress;
-
   List<EligibilityCode> eligibilityCodes;
 
   Boolean grandfathered;
 
   Boolean noFullServiceVaMedicalFacility;
+
+  Address patientAddress;
 
   List<Facility> nearbyFacilities;
 

--- a/community-care-eligibility-api/src/main/java/gov/va/api/health/communitycareeligibility/api/CommunityCareEligibilityResponse.java
+++ b/community-care-eligibility-api/src/main/java/gov/va/api/health/communitycareeligibility/api/CommunityCareEligibilityResponse.java
@@ -23,6 +23,8 @@ public final class CommunityCareEligibilityResponse {
 
   PatientRequest patientRequest;
 
+  Address patientAddress;
+
   List<EligibilityCode> eligibilityCodes;
 
   Boolean grandfathered;
@@ -129,8 +131,6 @@ public final class CommunityCareEligibilityResponse {
   public static final class PatientRequest {
 
     String patientIcn;
-
-    Address patientAddress;
 
     String serviceType;
 

--- a/community-care-eligibility-api/src/main/java/gov/va/api/health/communitycareeligibility/api/CommunityCareEligibilityService.java
+++ b/community-care-eligibility-api/src/main/java/gov/va/api/health/communitycareeligibility/api/CommunityCareEligibilityService.java
@@ -38,9 +38,7 @@ import javax.ws.rs.Path;
 @Path("/")
 public interface CommunityCareEligibilityService {
   @Operation(
-    summary =
-        "Compute community care eligibility by patient ICN, patient home address,"
-            + " and desired medical service type",
+    summary = "Compute community care eligibility by patient ICN and desired medical service type",
     tags = "Search"
   )
   @GET
@@ -81,38 +79,6 @@ public interface CommunityCareEligibilityService {
           )
           @NotBlank
           String patientIcn,
-      @Parameter(
-            in = ParameterIn.QUERY,
-            required = true,
-            name = "street",
-            description = "Street of patient's home address"
-          )
-          @NotBlank
-          String street,
-      @Parameter(
-            in = ParameterIn.QUERY,
-            required = true,
-            name = "city",
-            description = "City of patient's home address"
-          )
-          @NotBlank
-          String city,
-      @Parameter(
-            in = ParameterIn.QUERY,
-            required = true,
-            name = "state",
-            description = "State of patient's home address"
-          )
-          @NotBlank
-          String state,
-      @Parameter(
-            in = ParameterIn.QUERY,
-            required = true,
-            name = "zip",
-            description = "ZIP code of patient's home address"
-          )
-          @NotBlank
-          String zip,
       @Parameter(
             in = ParameterIn.QUERY,
             required = true,

--- a/community-care-eligibility-api/src/test/java/gov/va/api/health/communitycareeligibility/api/swaggerexamples/SwaggerCommunityCareEligibilityResponse.java
+++ b/community-care-eligibility-api/src/test/java/gov/va/api/health/communitycareeligibility/api/swaggerexamples/SwaggerCommunityCareEligibilityResponse.java
@@ -17,15 +17,15 @@ class SwaggerCommunityCareEligibilityResponse {
               .patientRequest(
                   PatientRequest.builder()
                       .patientIcn("011235813V213455")
-                      .patientAddress(
-                          Address.builder()
-                              .street("742 Evergeen Terrace")
-                              .city("Springfield")
-                              .state("KY")
-                              .zip("89144")
-                              .build())
                       .serviceType("PrimaryCare")
                       .timestamp("2019-05-09T13:17:58.250Z")
+                      .build())
+              .patientAddress(
+                  Address.builder()
+                      .street("742 Evergeen Terrace")
+                      .city("Springfield")
+                      .state("KY")
+                      .zip("89144")
                       .build())
               .eligibilityCodes(
                   asList(

--- a/community-care-eligibility/pom.xml
+++ b/community-care-eligibility/pom.xml
@@ -12,7 +12,7 @@
   <packaging>jar</packaging>
   <properties>
     <ee-artifacts.version>1.1.44</ee-artifacts.version>
-    <jacoco.coverage>0.87</jacoco.coverage>
+    <jacoco.coverage>0.86</jacoco.coverage>
   </properties>
   <dependencies>
     <dependency>

--- a/community-care-eligibility/pom.xml
+++ b/community-care-eligibility/pom.xml
@@ -12,7 +12,7 @@
   <packaging>jar</packaging>
   <properties>
     <ee-artifacts.version>1.1.44</ee-artifacts.version>
-    <jacoco.coverage>0.86</jacoco.coverage>
+    <jacoco.coverage>0.87</jacoco.coverage>
   </properties>
   <dependencies>
     <dependency>

--- a/community-care-eligibility/src/main/docker/entrypoint.sh
+++ b/community-care-eligibility/src/main/docker/entrypoint.sh
@@ -4,10 +4,6 @@ ENDPOINT_DOMAIN_NAME="$K8S_LOAD_BALANCER"
 ENVIRONMENT="$K8S_ENVIRONMENT"
 TOKEN="$TOKEN"
 BASE_PATH="$BASE_PATH"
-STREET="$STREET"
-CITY="$CITY"
-STATE="$STATE"
-ZIP="$ZIP"
 SERVICE_TYPE="$SERVICE_TYPE"
 PATIENT="$PATIENT"
 
@@ -37,10 +33,6 @@ Example
     --endpoint-domain-name=localhost
     --environment=qa
     --base-path=/community-care
-    --street='46 W New Haven Ave'
-    --city=Melbourne
-    --state=Fl
-    --zip=32901
     --service-type=PrimaryCare
     --patient=12345678V90
 
@@ -81,18 +73,18 @@ smokeTest() {
     done
 
   # Happy Path
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=$PATIENT"
+  path="/search?serviceType=$SERVICE_TYPE&patient=$PATIENT"
   doCurl 200 $TOKEN
 
   # Token validation
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=$PATIENT"
+  path="/search?serviceType=$SERVICE_TYPE&patient=$PATIENT"
   doCurl 401 "BADTOKEN"
 
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=123NOTME"
+  path="/search?serviceType=$SERVICE_TYPE&patient=123NOTME"
   doCurl 403 $TOKEN
 
   # Single missing parameter check for smoke test
-  path="/search?city=$CITY&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=$PATIENT"
+  path="/search?serviceType=$SERVICE_TYPE"
   doCurl 500 $TOKEN
 
   printResults
@@ -110,42 +102,33 @@ regressionTest() {
     done
 
   # Happy Path Primary Care
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=PrimaryCare&patient=$PATIENT"
+  path="/search?serviceType=PrimaryCare&patient=$PATIENT"
   doCurl 200 $TOKEN
 
   # Happy Path Primary Care
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=PrimaryCare&patient=$PATIENT"
+  path="/search?serviceType=PrimaryCare&patient=$PATIENT"
   doCurl 200 $TOKEN
 
   # Happy Path Specialty Care (Audiology)
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=Audiology&patient=$PATIENT"
+  path="/search?serviceType=Audiology&patient=$PATIENT"
   doCurl 200 $TOKEN
 
   # Happy Path Specialty Care (Audiology)
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=Audiology&patient=$PATIENT"
+  path="/search?serviceType=Audiology&patient=$PATIENT"
   doCurl 200 $TOKEN
 
   # Token validation
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=$PATIENT"
+  path="/search?serviceType=$SERVICE_TYPE&patient=$PATIENT"
   doCurl 401 "BADTOKEN"
 
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=123NOTME"
+  path="/search?serviceType=$SERVICE_TYPE&patient=123NOTME"
   doCurl 403 $TOKEN
 
   # Missing Parameters
-  path="/search?city=$CITY&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=$PATIENT"
+  path="/search?serviceType=$SERVICE_TYPE"
   doCurl 500 $TOKEN
 
-  path="/search?street=$STREET&state=$STATE&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=$PATIENT"
-  doCurl 500 $TOKEN
-
-  path="/search?street=$STREET&city=$CITY&zip=$ZIP&serviceType=$SERVICE_TYPE&patient=$PATIENT"
-  doCurl 500 $TOKEN
-
-  path="/search?street=$STREET&city=$CITY&state=$STATE&serviceType=$SERVICE_TYPE&patient=$PATIENT"
-  doCurl 500 $TOKEN
-
-  path="/search?street=$STREET&city=$CITY&state=$STATE&zip=$ZIP&patient=$PATIENT"
+  path="/search?patient=$PATIENT"
   doCurl 500 $TOKEN
 
   printResults
@@ -163,8 +146,8 @@ printResults () {
 
 # Let's get down to business
 ARGS=$(getopt -n $(basename ${0}) \
-    -l "endpoint-domain-name:,environment:,token:,base-path:,street:,city:,state:,zip:,service-type:,patient:,help" \
-    -o "d:e:t:b:s:c:a:z:v:p:h" -- "$@")
+    -l "endpoint-domain-name:,environment:,token:,base-path:,service-type:,patient:,help" \
+    -o "d:e:t:b:v:p:h" -- "$@")
 [ $? != 0 ] && usage
 eval set -- "$ARGS"
 while true
@@ -174,10 +157,6 @@ do
     -e|--environment) ENVIRONMENT=$2;;
     -t|--token) TOKEN=$2;;
     -b|--base-path) BASE_PATH=$2;;
-    -s|--street) STREET=$2;;
-    -c|--city) CITY=$2;;
-    -a|--state) STATE=$2;;
-    -z|--zip) ZIP=$2;;
     -v|--service-type) SERVICE_TYPE=$2;;
     -p|--patient) PATIENT=$2;;
     -h|--help) usage "I need a hero! I'm holding out for a hero...";;
@@ -196,22 +175,6 @@ fi
 
 if [[ -z "$TOKEN" || -e "$TOKEN" ]]; then
   usage "Missing variable TOKEN or option --token|-t."
-fi
-
-if [[ -z "$STREET" || -e "$STREET" ]]; then
-  usage "Missing variable STREET or option --street|-s."
-fi
-
-if [[ -z "$CITY" || -e "$CITY" ]]; then
-  usage "Missing variable CITY or option --city|-c."
-fi
-
-if [[ -z "$STATE" || -e "$STATE" ]]; then
-  usage "Missing variable STATE or option --state|-a."
-fi
-
-if [[ -z "$ZIP" || -e "$ZIP" ]]; then
-  usage "Missing variable ZIP or option --zip|-z."
 fi
 
 if [[ -z "$SERVICE_TYPE" || -e "$SERVICE_TYPE" ]]; then

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
@@ -72,19 +72,20 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
   private static Address parsePatientAddress(AddressInfo addressInfo) {
     String zip = trimToEmpty(addressInfo.getZipCode());
     if (zip.isEmpty()) {
-      if (addressInfo.getPostalCode().isEmpty()) {
+      if (trimToEmpty(addressInfo.getPostalCode()).isEmpty()) {
         zip = trimToEmpty(addressInfo.getZipcode());
+      } else {
+        zip = trimToEmpty(addressInfo.getPostalCode());
       }
-      zip = trimToEmpty(addressInfo.getPostalCode());
     }
-
-    if (addressInfo.getZipPlus4() != null && !zip.isEmpty()) {
-      zip = zip + "-" + trimToEmpty(addressInfo.getZipPlus4());
+    String zipPlus4 = trimToEmpty(addressInfo.getZipPlus4());
+    if (!zip.isEmpty() && !zipPlus4.isEmpty()) {
+      zip = zip + "-" + zipPlus4;
     }
     Address patientAddress =
         Address.builder()
             .city(trimToEmpty(addressInfo.getCity()))
-            .state(trimToEmpty(addressInfo.getState().toUpperCase()))
+            .state(trimToEmpty(addressInfo.getState()).toUpperCase())
             .street(
                 trimToEmpty(
                     trimToEmpty(addressInfo.getLine1())

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -27,4 +27,16 @@ final class Exceptions {
       super("Unknown service type: " + serviceType);
     }
   }
+
+  static final class MissingResidentialAddressException extends NullPointerException {
+    MissingResidentialAddressException() {
+      super("No residential address found");
+    }
+  }
+
+  static final class MissingAddressInformationException extends NullPointerException {
+    MissingAddressInformationException() {
+      super("Residential address has incomplete information");
+    }
+  }
 }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -19,8 +19,7 @@ final class Exceptions {
 
   static final class IncompleteAddressException extends RuntimeException {
     IncompleteAddressException(Address patientAddress) {
-      super(
-          "Residential address has incomplete information: " + patientAddress);
+      super("Residential address has incomplete information: " + patientAddress);
     }
   }
 

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -17,24 +17,6 @@ final class Exceptions {
     }
   }
 
-  static final class UnknownPatientIcnException extends RuntimeException {
-    UnknownPatientIcnException(String patientIcn, Throwable cause) {
-      super("Unknown patient ICN: " + patientIcn, cause);
-    }
-  }
-
-  static final class UnknownServiceTypeException extends RuntimeException {
-    UnknownServiceTypeException(String serviceType) {
-      super("Unknown service type: " + serviceType);
-    }
-  }
-
-  static final class MissingResidentialAddressException extends RuntimeException {
-    MissingResidentialAddressException(String patientIcn) {
-      super("No residential address found for ICN: " + patientIcn);
-    }
-  }
-
   static final class IncompleteAddressException extends RuntimeException {
     IncompleteAddressException(Address patientAddress) {
       super(
@@ -51,6 +33,24 @@ final class Exceptions {
               + System.lineSeparator()
               + "Zipcode: "
               + patientAddress.zip());
+    }
+  }
+
+  static final class MissingResidentialAddressException extends RuntimeException {
+    MissingResidentialAddressException(String patientIcn) {
+      super("No residential address found for ICN: " + patientIcn);
+    }
+  }
+
+  static final class UnknownPatientIcnException extends RuntimeException {
+    UnknownPatientIcnException(String patientIcn, Throwable cause) {
+      super("Unknown patient ICN: " + patientIcn, cause);
+    }
+  }
+
+  static final class UnknownServiceTypeException extends RuntimeException {
+    UnknownServiceTypeException(String serviceType) {
+      super("Unknown service type: " + serviceType);
     }
   }
 }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -1,5 +1,6 @@
 package gov.va.api.health.communitycareeligibility.service;
 
+import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -28,15 +29,28 @@ final class Exceptions {
     }
   }
 
-  static final class MissingResidentialAddressException extends NullPointerException {
-    MissingResidentialAddressException() {
-      super("No residential address found");
+  static final class MissingResidentialAddressException extends RuntimeException {
+    MissingResidentialAddressException(String patientIcn) {
+      super("No residential address found for ICN: " + patientIcn);
     }
   }
 
-  static final class MissingAddressInformationException extends NullPointerException {
-    MissingAddressInformationException() {
-      super("Residential address has incomplete information");
+  static final class IncompleteAddressException extends RuntimeException {
+    IncompleteAddressException(Address patientAddress) {
+      super(
+          "Residential address has incomplete information"
+              + System.lineSeparator()
+              + "Street: "
+              + patientAddress.street()
+              + System.lineSeparator()
+              + "City: "
+              + patientAddress.city()
+              + System.lineSeparator()
+              + "State: "
+              + patientAddress.state()
+              + System.lineSeparator()
+              + "Zipcode: "
+              + patientAddress.zip());
     }
   }
 }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -20,19 +20,7 @@ final class Exceptions {
   static final class IncompleteAddressException extends RuntimeException {
     IncompleteAddressException(Address patientAddress) {
       super(
-          "Residential address has incomplete information"
-              + System.lineSeparator()
-              + "Street: "
-              + patientAddress.street()
-              + System.lineSeparator()
-              + "City: "
-              + patientAddress.city()
-              + System.lineSeparator()
-              + "State: "
-              + patientAddress.state()
-              + System.lineSeparator()
-              + "Zipcode: "
-              + patientAddress.zip());
+          "Residential address has incomplete information: " + patientAddress);
     }
   }
 

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
@@ -12,12 +12,18 @@ import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityRe
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Coordinates;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Facility;
+import gov.va.med.esr.webservices.jaxws.schemas.AddressCollection;
+import gov.va.med.esr.webservices.jaxws.schemas.AddressInfo;
 import gov.va.med.esr.webservices.jaxws.schemas.CommunityCareEligibilityInfo;
+import gov.va.med.esr.webservices.jaxws.schemas.ContactInfo;
+import gov.va.med.esr.webservices.jaxws.schemas.DemographicInfo;
 import gov.va.med.esr.webservices.jaxws.schemas.EeSummary;
 import gov.va.med.esr.webservices.jaxws.schemas.GetEESummaryResponse;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityCollection;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityInfo;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -76,18 +82,45 @@ public final class CommunityCareEligibilityTest {
                                     .build())
                             .build()))
                 .build());
-
+    EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
+    when(client.requestEligibility("123"))
+        .thenReturn(
+            GetEESummaryResponse.builder()
+                .summary(
+                    EeSummary.builder()
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    new ArrayList<AddressInfo>(
+                                                        Arrays.asList(
+                                                            AddressInfo.builder()
+                                                                .addressTypeCode("Residential")
+                                                                .state("FL")
+                                                                .city("Melbourne")
+                                                                .line1("66 Main St")
+                                                                .line2("")
+                                                                .line3("")
+                                                                .zipCode("12345")
+                                                                .build())))
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build());
     CommunityCareEligibilityV0ApiController controller =
         CommunityCareEligibilityV0ApiController.builder()
             .facilitiesClient(facilitiesClient)
-            .eeClient(mock(EligibilityAndEnrollmentClient.class))
+            .eeClient(client)
             .maxDriveTimePrimary(60)
             .maxDriveTimeSpecialty(60)
             .maxWaitPrimary(2)
             .maxWaitSpecialty(2)
             .build();
-    CommunityCareEligibilityResponse actual =
-        controller.search("123", "66 Main St", "Melbourne", "fl", "12345", "Audiology");
+    CommunityCareEligibilityResponse actual = controller.search("123", "Audiology");
     CommunityCareEligibilityResponse expected =
         CommunityCareEligibilityResponse.builder()
             .patientRequest(
@@ -164,16 +197,44 @@ public final class CommunityCareEligibilityTest {
                                     .build())
                             .build()))
                 .build());
-
+    EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
+    when(client.requestEligibility("123"))
+        .thenReturn(
+            GetEESummaryResponse.builder()
+                .summary(
+                    EeSummary.builder()
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    new ArrayList<AddressInfo>(
+                                                        Arrays.asList(
+                                                            AddressInfo.builder()
+                                                                .addressTypeCode("Residential")
+                                                                .state("FL")
+                                                                .city("Melbourne")
+                                                                .line1("66 Main St")
+                                                                .line2("")
+                                                                .line3("")
+                                                                .zipCode("12345")
+                                                                .build())))
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build());
     CommunityCareEligibilityV0ApiController controller =
         CommunityCareEligibilityV0ApiController.builder()
             .maxDriveTimePrimary(10)
             .maxWaitPrimary(5)
             .facilitiesClient(facilitiesClient)
-            .eeClient(mock(EligibilityAndEnrollmentClient.class))
+            .eeClient(client)
             .build();
-    CommunityCareEligibilityResponse actual =
-        controller.search("123", " 66 Main St", "Melbourne  ", " fl", " 12345 ", "primarycare");
+
+    CommunityCareEligibilityResponse actual = controller.search("123", "primarycare");
     CommunityCareEligibilityResponse expected =
         CommunityCareEligibilityResponse.builder()
             .patientRequest(
@@ -209,13 +270,41 @@ public final class CommunityCareEligibilityTest {
   @Test
   @SneakyThrows
   public void empty() {
+    EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
+    when(client.requestEligibility("123"))
+        .thenReturn(
+            GetEESummaryResponse.builder()
+                .summary(
+                    EeSummary.builder()
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    new ArrayList<AddressInfo>(
+                                                        Arrays.asList(
+                                                            AddressInfo.builder()
+                                                                .addressTypeCode("Residential")
+                                                                .state("FL")
+                                                                .city("Melbourne")
+                                                                .line1("66 Main St")
+                                                                .line2("")
+                                                                .line3("")
+                                                                .zipCode("12345")
+                                                                .build())))
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build());
     CommunityCareEligibilityV0ApiController controller =
         CommunityCareEligibilityV0ApiController.builder()
             .facilitiesClient(mock(FacilitiesClient.class))
-            .eeClient(mock(EligibilityAndEnrollmentClient.class))
+            .eeClient(client)
             .build();
-    CommunityCareEligibilityResponse result =
-        controller.search("123", "66 Main St", "Melbourne", "fl", "12345 ", "primarycare");
+    CommunityCareEligibilityResponse result = controller.search("123", "primarycare");
     assertThat(result)
         .isEqualTo(
             CommunityCareEligibilityResponse.builder()
@@ -310,10 +399,37 @@ public final class CommunityCareEligibilityTest {
                                                     .build()))
                                         .build())
                                 .build())
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    new ArrayList<AddressInfo>(
+                                                        Arrays.asList(
+                                                            AddressInfo.builder()
+                                                                .addressTypeCode("Residential")
+                                                                .state("FL")
+                                                                .city("Melbourne")
+                                                                .line1("66 Main St")
+                                                                .line2("")
+                                                                .line3("Apt. 602")
+                                                                .zipCode("12345")
+                                                                .zipPlus4("0104")
+                                                                .build())))
+                                                .build())
+                                        .build())
+                                .build())
                         .build())
                 .build());
     Address patientAddress =
-        Address.builder().city("Melbourne").state("FL").zip("12345").street("66 Main St").build();
+        Address.builder()
+            .city("Melbourne")
+            .state("FL")
+            .zip("12345-0104")
+            .street("66 Main St Apt. 602")
+            .build();
 
     FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
     when(facilitiesClient.nearbyFacilities(patientAddress, 1, "PrimaryCare"))
@@ -364,8 +480,7 @@ public final class CommunityCareEligibilityTest {
             .maxWaitPrimary(1)
             .eeClient(eeClient)
             .build();
-    CommunityCareEligibilityResponse actual =
-        controller.search("123", " 66 Main St", "Melbourne  ", " fl", " 12345 ", "primarycare");
+    CommunityCareEligibilityResponse actual = controller.search("123", "primarycare");
     CommunityCareEligibilityResponse expected =
         CommunityCareEligibilityResponse.builder()
             .patientRequest(
@@ -374,8 +489,8 @@ public final class CommunityCareEligibilityTest {
                         Address.builder()
                             .state("FL")
                             .city("Melbourne")
-                            .zip("12345")
-                            .street("66 Main St")
+                            .zip("12345-0104")
+                            .street("66 Main St Apt. 602")
                             .build())
                     .timestamp(actual.patientRequest().timestamp())
                     .patientIcn("123")
@@ -418,6 +533,27 @@ public final class CommunityCareEligibilityTest {
                                                     .build()))
                                         .build())
                                 .build())
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    new ArrayList<AddressInfo>(
+                                                        Arrays.asList(
+                                                            AddressInfo.builder()
+                                                                .addressTypeCode("Residential")
+                                                                .state("FL")
+                                                                .city("Melbourne")
+                                                                .line1("66 Main St")
+                                                                .line2("")
+                                                                .line3("")
+                                                                .zipCode("12345")
+                                                                .build())))
+                                                .build())
+                                        .build())
+                                .build())
                         .build())
                 .build());
     FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
@@ -430,22 +566,50 @@ public final class CommunityCareEligibilityTest {
             .maxDriveTimePrimary(1)
             .maxWaitPrimary(1)
             .build();
-    CommunityCareEligibilityResponse result =
-        controller.search("123", " 66 Main St", "Melbourne  ", " fl", " 12345 ", "primarycare");
+    CommunityCareEligibilityResponse result = controller.search("123", "primarycare");
     assertThat(result.nearbyFacilities().isEmpty());
   }
 
   @SneakyThrows
   @Test(expected = Exceptions.UnknownServiceTypeException.class)
   public void unknownServiceType() {
+    EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
+    when(client.requestEligibility("123"))
+        .thenReturn(
+            GetEESummaryResponse.builder()
+                .summary(
+                    EeSummary.builder()
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    new ArrayList<AddressInfo>(
+                                                        Arrays.asList(
+                                                            AddressInfo.builder()
+                                                                .addressTypeCode("Residential")
+                                                                .state("FL")
+                                                                .city("Melbourne")
+                                                                .line1("66 Main St")
+                                                                .line2("")
+                                                                .line3("")
+                                                                .zipCode("12345")
+                                                                .build())))
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build());
     CommunityCareEligibilityV0ApiController controller =
         CommunityCareEligibilityV0ApiController.builder()
             .facilitiesClient(mock(FacilitiesClient.class))
-            .eeClient(mock(EligibilityAndEnrollmentClient.class))
+            .eeClient(client)
             .maxDriveTimePrimary(1)
             .maxWaitPrimary(1)
             .build();
-    controller.search("123", " 66 Main St", "Melbourne  ", " fl", " 12345 ", "Dentistry");
+    controller.search("123", "Dentistry");
   }
 
   @Test
@@ -470,6 +634,27 @@ public final class CommunityCareEligibilityTest {
                                                         parseXmlGregorianCalendar(
                                                             "2019-03-27T14:37:48Z"))
                                                     .build()))
+                                        .build())
+                                .build())
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    new ArrayList<AddressInfo>(
+                                                        Arrays.asList(
+                                                            AddressInfo.builder()
+                                                                .addressTypeCode("Residential")
+                                                                .state("FL")
+                                                                .city("Melbourne")
+                                                                .line1("66 Main St")
+                                                                .line2("")
+                                                                .line3("")
+                                                                .zipCode("12345")
+                                                                .build())))
+                                                .build())
                                         .build())
                                 .build())
                         .build())
@@ -518,8 +703,7 @@ public final class CommunityCareEligibilityTest {
             .maxDriveTimePrimary(60)
             .maxWaitPrimary(2)
             .build();
-    CommunityCareEligibilityResponse actual =
-        controller.search("123", "66 Main St", "Melbourne", "fl", "12345", "optometry");
+    CommunityCareEligibilityResponse actual = controller.search("123", "optometry");
     CommunityCareEligibilityResponse expected =
         CommunityCareEligibilityResponse.builder()
             .grandfathered(false)

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
@@ -507,11 +507,6 @@ public final class CommunityCareEligibilityTest {
                                                     asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
-                                                            .state("FL")
-                                                            .line1("66 Main St")
-                                                            .line2("")
-                                                            .line3("")
-                                                            .zipCode("12345")
                                                             .build()))
                                                 .build())
                                         .build())

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
@@ -22,7 +22,6 @@ import gov.va.med.esr.webservices.jaxws.schemas.GetEESummaryResponse;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityCollection;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityInfo;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -95,17 +94,16 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    new ArrayList<AddressInfo>(
-                                                        Arrays.asList(
-                                                            AddressInfo.builder()
-                                                                .addressTypeCode("Residential")
-                                                                .state("FL")
-                                                                .city("Melbourne")
-                                                                .line1("66 Main St")
-                                                                .line2("")
-                                                                .line3("")
-                                                                .zipCode("12345")
-                                                                .build())))
+                                                    Arrays.asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("Residential")
+                                                            .state("FL")
+                                                            .city("Melbourne")
+                                                            .line1("66 Main St")
+                                                            .line2("")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .build()))
                                                 .build())
                                         .build())
                                 .build())
@@ -210,17 +208,16 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    new ArrayList<AddressInfo>(
-                                                        Arrays.asList(
-                                                            AddressInfo.builder()
-                                                                .addressTypeCode("Residential")
-                                                                .state("FL")
-                                                                .city("Melbourne")
-                                                                .line1("66 Main St")
-                                                                .line2("")
-                                                                .line3("")
-                                                                .zipCode("12345")
-                                                                .build())))
+                                                    Arrays.asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("Residential")
+                                                            .state("FL")
+                                                            .city("Melbourne")
+                                                            .line1("66 Main St")
+                                                            .line2("")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .build()))
                                                 .build())
                                         .build())
                                 .build())
@@ -283,17 +280,16 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    new ArrayList<AddressInfo>(
-                                                        Arrays.asList(
-                                                            AddressInfo.builder()
-                                                                .addressTypeCode("Residential")
-                                                                .state("FL")
-                                                                .city("Melbourne")
-                                                                .line1("66 Main St")
-                                                                .line2("")
-                                                                .line3("")
-                                                                .zipCode("12345")
-                                                                .build())))
+                                                    Arrays.asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("Residential")
+                                                            .state("FL")
+                                                            .city("Melbourne")
+                                                            .line1("66 Main St")
+                                                            .line2("")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .build()))
                                                 .build())
                                         .build())
                                 .build())
@@ -406,18 +402,17 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    new ArrayList<AddressInfo>(
-                                                        Arrays.asList(
-                                                            AddressInfo.builder()
-                                                                .addressTypeCode("Residential")
-                                                                .state("FL")
-                                                                .city("Melbourne")
-                                                                .line1("66 Main St")
-                                                                .line2("")
-                                                                .line3("Apt. 602")
-                                                                .zipCode("12345")
-                                                                .zipPlus4("0104")
-                                                                .build())))
+                                                    Arrays.asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("Residential")
+                                                            .state("FL")
+                                                            .city("Melbourne")
+                                                            .line1("66 Main St")
+                                                            .line2("Apt. 602")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .zipPlus4("0104")
+                                                            .build()))
                                                 .build())
                                         .build())
                                 .build())
@@ -540,17 +535,16 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    new ArrayList<AddressInfo>(
-                                                        Arrays.asList(
-                                                            AddressInfo.builder()
-                                                                .addressTypeCode("Residential")
-                                                                .state("FL")
-                                                                .city("Melbourne")
-                                                                .line1("66 Main St")
-                                                                .line2("")
-                                                                .line3("")
-                                                                .zipCode("12345")
-                                                                .build())))
+                                                    Arrays.asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("Residential")
+                                                            .state("FL")
+                                                            .city("Melbourne")
+                                                            .line1("66 Main St")
+                                                            .line2("")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .build()))
                                                 .build())
                                         .build())
                                 .build())
@@ -586,17 +580,16 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    new ArrayList<AddressInfo>(
-                                                        Arrays.asList(
-                                                            AddressInfo.builder()
-                                                                .addressTypeCode("Residential")
-                                                                .state("FL")
-                                                                .city("Melbourne")
-                                                                .line1("66 Main St")
-                                                                .line2("")
-                                                                .line3("")
-                                                                .zipCode("12345")
-                                                                .build())))
+                                                    Arrays.asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("Residential")
+                                                            .state("FL")
+                                                            .city("Melbourne")
+                                                            .line1("66 Main St")
+                                                            .line2("")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .build()))
                                                 .build())
                                         .build())
                                 .build())
@@ -643,17 +636,16 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    new ArrayList<AddressInfo>(
-                                                        Arrays.asList(
-                                                            AddressInfo.builder()
-                                                                .addressTypeCode("Residential")
-                                                                .state("FL")
-                                                                .city("Melbourne")
-                                                                .line1("66 Main St")
-                                                                .line2("")
-                                                                .line3("")
-                                                                .zipCode("12345")
-                                                                .build())))
+                                                    Arrays.asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("Residential")
+                                                            .state("FL")
+                                                            .city("Melbourne")
+                                                            .line1("66 Main St")
+                                                            .line2("")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .build()))
                                                 .build())
                                         .build())
                                 .build())

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
@@ -22,7 +22,6 @@ import gov.va.med.esr.webservices.jaxws.schemas.GetEESummaryResponse;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityCollection;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityInfo;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -32,6 +31,7 @@ import lombok.SneakyThrows;
 import org.junit.Test;
 
 public final class CommunityCareEligibilityTest {
+
   @SneakyThrows
   private static XMLGregorianCalendar parseXmlGregorianCalendar(String timestamp) {
     GregorianCalendar gCal = new GregorianCalendar();
@@ -46,7 +46,6 @@ public final class CommunityCareEligibilityTest {
     Address patientAddress =
         Address.builder().city("Melbourne").state("FL").zip("12345").street("66 Main St").build();
     FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
-
     when(facilitiesClient.nearbyFacilities(patientAddress, 60, "Audiology"))
         .thenReturn(
             VaFacilitiesResponse.builder()
@@ -94,7 +93,7 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    Arrays.asList(
+                                                    asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
                                                             .state("FL")
@@ -124,15 +123,15 @@ public final class CommunityCareEligibilityTest {
             .patientRequest(
                 CommunityCareEligibilityResponse.PatientRequest.builder()
                     .patientIcn("123")
-                    .patientAddress(
-                        Address.builder()
-                            .state("FL")
-                            .city("Melbourne")
-                            .zip("12345")
-                            .street("66 Main St")
-                            .build())
                     .timestamp(actual.patientRequest().timestamp())
                     .serviceType("Audiology")
+                    .build())
+            .patientAddress(
+                Address.builder()
+                    .state("FL")
+                    .city("Melbourne")
+                    .zip("12345")
+                    .street("66 Main St")
                     .build())
             .eligible(false)
             .eligibilityCodes(emptyList())
@@ -160,7 +159,6 @@ public final class CommunityCareEligibilityTest {
     Address patientAddress =
         Address.builder().city("Melbourne").state("FL").zip("12345").street("66 Main St").build();
     FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
-
     when(facilitiesClient.nearbyFacilities(patientAddress, 10, "PrimaryCare"))
         .thenReturn(
             VaFacilitiesResponse.builder()
@@ -208,7 +206,7 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    Arrays.asList(
+                                                    asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
                                                             .state("FL")
@@ -230,23 +228,22 @@ public final class CommunityCareEligibilityTest {
             .facilitiesClient(facilitiesClient)
             .eeClient(client)
             .build();
-
     CommunityCareEligibilityResponse actual = controller.search("123", "primarycare");
     CommunityCareEligibilityResponse expected =
         CommunityCareEligibilityResponse.builder()
             .patientRequest(
                 (CommunityCareEligibilityResponse.PatientRequest.builder()
-                    .patientAddress(
-                        Address.builder()
-                            .state("FL")
-                            .city("Melbourne")
-                            .zip("12345")
-                            .street("66 Main St")
-                            .build())
                     .timestamp(actual.patientRequest().timestamp())
                     .patientIcn("123")
                     .serviceType("PrimaryCare")
                     .build()))
+            .patientAddress(
+                Address.builder()
+                    .state("FL")
+                    .city("Melbourne")
+                    .zip("12345")
+                    .street("66 Main St")
+                    .build())
             .eligibilityCodes(emptyList())
             .grandfathered(false)
             .noFullServiceVaMedicalFacility(false)
@@ -280,7 +277,7 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    Arrays.asList(
+                                                    asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
                                                             .state("FL")
@@ -306,16 +303,16 @@ public final class CommunityCareEligibilityTest {
             CommunityCareEligibilityResponse.builder()
                 .patientRequest(
                     CommunityCareEligibilityResponse.PatientRequest.builder()
-                        .patientAddress(
-                            Address.builder()
-                                .state("FL")
-                                .city("Melbourne")
-                                .zip("12345")
-                                .street("66 Main St")
-                                .build())
                         .patientIcn("123")
                         .timestamp(result.patientRequest().timestamp())
                         .serviceType("PrimaryCare")
+                        .build())
+                .patientAddress(
+                    Address.builder()
+                        .state("FL")
+                        .city("Melbourne")
+                        .zip("12345")
+                        .street("66 Main St")
                         .build())
                 .eligibilityCodes(emptyList())
                 .grandfathered(false)
@@ -328,14 +325,11 @@ public final class CommunityCareEligibilityTest {
   @SneakyThrows
   public void facilityTransformerNullChecks() {
     FacilityTransformer transformer = FacilityTransformer.builder().serviceType("xyz").build();
-
     // facility is null
     assertThat(transformer.toFacility(null)).isNull();
-
     // top level attributes is null
     assertThat(transformer.toFacility(VaFacilitiesResponse.Facility.builder().build()))
         .isEqualTo(Facility.builder().build());
-
     // empty attributes
     assertThat(
             transformer.toFacility(
@@ -343,7 +337,6 @@ public final class CommunityCareEligibilityTest {
                     .attributes(VaFacilitiesResponse.Attributes.builder().build())
                     .build()))
         .isEqualTo(Facility.builder().build());
-
     // empty address
     assertThat(
             transformer.toFacility(
@@ -354,7 +347,6 @@ public final class CommunityCareEligibilityTest {
                             .build())
                     .build()))
         .isEqualTo(Facility.builder().build());
-
     // empty physical address
     assertThat(
             transformer.toFacility(
@@ -402,7 +394,7 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    Arrays.asList(
+                                                    asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
                                                             .state("FL")
@@ -425,7 +417,6 @@ public final class CommunityCareEligibilityTest {
             .zip("12345-0104")
             .street("66 Main St Apt. 602")
             .build();
-
     FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
     when(facilitiesClient.nearbyFacilities(patientAddress, 1, "PrimaryCare"))
         .thenReturn(
@@ -480,13 +471,6 @@ public final class CommunityCareEligibilityTest {
         CommunityCareEligibilityResponse.builder()
             .patientRequest(
                 (CommunityCareEligibilityResponse.PatientRequest.builder()
-                    .patientAddress(
-                        Address.builder()
-                            .state("FL")
-                            .city("Melbourne")
-                            .zip("12345-0104")
-                            .street("66 Main St Apt. 602")
-                            .build())
                     .timestamp(actual.patientRequest().timestamp())
                     .patientIcn("123")
                     .serviceType("PrimaryCare")
@@ -502,6 +486,81 @@ public final class CommunityCareEligibilityTest {
                         .build()))
             .build();
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test(expected = Exceptions.MissingAddressInformationException.class)
+  public void missingAddressInfo() {
+    EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
+    when(client.requestEligibility("123"))
+        .thenReturn(
+            GetEESummaryResponse.builder()
+                .summary(
+                    EeSummary.builder()
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("Residential")
+                                                            .state("FL")
+                                                            .line1("66 Main St")
+                                                            .line2("")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .build()))
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build());
+    CommunityCareEligibilityV0ApiController controller =
+        CommunityCareEligibilityV0ApiController.builder()
+            .facilitiesClient(mock(FacilitiesClient.class))
+            .eeClient(client)
+            .build();
+    controller.search("123", "PrimaryCare");
+  }
+
+  @Test(expected = Exceptions.MissingResidentialAddressException.class)
+  public void noResidentialFound() {
+    EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
+    when(client.requestEligibility("123"))
+        .thenReturn(
+            GetEESummaryResponse.builder()
+                .summary(
+                    EeSummary.builder()
+                        .demographics(
+                            DemographicInfo.builder()
+                                .contactInfo(
+                                    ContactInfo.builder()
+                                        .addresses(
+                                            AddressCollection.builder()
+                                                .address(
+                                                    asList(
+                                                        AddressInfo.builder()
+                                                            .addressTypeCode("NON_RESIDENTIAL")
+                                                            .state("FL")
+                                                            .city("Melbourne")
+                                                            .line1("66 Main St")
+                                                            .line2("")
+                                                            .line3("")
+                                                            .zipCode("12345")
+                                                            .build()))
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build());
+    CommunityCareEligibilityV0ApiController controller =
+        CommunityCareEligibilityV0ApiController.builder()
+            .facilitiesClient(mock(FacilitiesClient.class))
+            .eeClient(client)
+            .build();
+    controller.search("123", "PrimaryCare");
   }
 
   @Test
@@ -535,7 +594,7 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    Arrays.asList(
+                                                    asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
                                                             .state("FL")
@@ -580,7 +639,7 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    Arrays.asList(
+                                                    asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
                                                             .state("FL")
@@ -636,7 +695,7 @@ public final class CommunityCareEligibilityTest {
                                         .addresses(
                                             AddressCollection.builder()
                                                 .address(
-                                                    Arrays.asList(
+                                                    asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
                                                             .state("FL")
@@ -703,13 +762,6 @@ public final class CommunityCareEligibilityTest {
             .patientRequest(
                 CommunityCareEligibilityResponse.PatientRequest.builder()
                     .patientIcn("123")
-                    .patientAddress(
-                        Address.builder()
-                            .state("FL")
-                            .city("Melbourne")
-                            .zip("12345")
-                            .street("66 Main St")
-                            .build())
                     .timestamp(actual.patientRequest().timestamp())
                     .serviceType("Optometry")
                     .build())
@@ -721,7 +773,6 @@ public final class CommunityCareEligibilityTest {
                         .code("X")
                         .build()))
             .build();
-
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
@@ -488,7 +488,8 @@ public final class CommunityCareEligibilityTest {
     assertThat(actual).isEqualTo(expected);
   }
 
-  @Test(expected = Exceptions.MissingAddressInformationException.class)
+  @SneakyThrows
+  @Test(expected = Exceptions.IncompleteAddressException.class)
   public void missingAddressInfo() {
     EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
     when(client.requestEligibility("123"))
@@ -525,6 +526,7 @@ public final class CommunityCareEligibilityTest {
     controller.search("123", "PrimaryCare");
   }
 
+  @SneakyThrows
   @Test(expected = Exceptions.MissingResidentialAddressException.class)
   public void noResidentialFound() {
     EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);


### PR DESCRIPTION
JIRA: https://vasdvp.atlassian.net/browse/CCE-108

Removed the need for address parameters when querying a patient's information. 

For the `smoke-tests` and `regression-tests`, I was unable get the docker test to pass the `Token validation` tests. Derek Brown suggested that a visual verification would be sufficient in this case.