### PR TITLE
CCE-132 Consume patient coordinates from E&E

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The medical service type is one of:
 * WomensHealth
 
 The API combines data from two sources:
-1. Patient physical address and eligibility information, from E&E.
+1. Patient physical address, latitude and longitude, and eligibility information, from E&E.
 2. VA health facilities in the state, from Facilities API.
 
 This data is used to compute an overall determination of community-care-eligibility
@@ -88,6 +88,10 @@ Sample response:
     "city" : "Springfield",
     "state" : "KY",
     "zip" : "89144"
+  },
+  "patientCoordinates" : {
+    "latitude" : 40.758541,
+    "longitude" : -73.982132
   },
   "nearbyFacilities" : [
     {

--- a/community-care-eligibility-api/src/main/java/gov/va/api/health/communitycareeligibility/api/CommunityCareEligibilityResponse.java
+++ b/community-care-eligibility-api/src/main/java/gov/va/api/health/communitycareeligibility/api/CommunityCareEligibilityResponse.java
@@ -2,6 +2,7 @@ package gov.va.api.health.communitycareeligibility.api;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -30,6 +31,8 @@ public final class CommunityCareEligibilityResponse {
   Boolean noFullServiceVaMedicalFacility;
 
   Address patientAddress;
+
+  Coordinates patientCoordinates;
 
   List<Facility> nearbyFacilities;
 
@@ -74,9 +77,9 @@ public final class CommunityCareEligibilityResponse {
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static final class Coordinates {
 
-    Double latitude;
+    BigDecimal latitude;
 
-    Double longitude;
+    BigDecimal longitude;
   }
 
   @Data

--- a/community-care-eligibility-api/src/test/java/gov/va/api/health/communitycareeligibility/api/swaggerexamples/SwaggerCommunityCareEligibilityResponse.java
+++ b/community-care-eligibility-api/src/test/java/gov/va/api/health/communitycareeligibility/api/swaggerexamples/SwaggerCommunityCareEligibilityResponse.java
@@ -7,6 +7,7 @@ import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityRe
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Coordinates;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Facility;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.PatientRequest;
+import java.math.BigDecimal;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -26,6 +27,11 @@ class SwaggerCommunityCareEligibilityResponse {
                       .city("Springfield")
                       .state("KY")
                       .zip("89144")
+                      .build())
+              .patientCoordinates(
+                  Coordinates.builder()
+                      .latitude(new BigDecimal("40.758541"))
+                      .longitude(new BigDecimal("-73.982132"))
                       .build())
               .eligibilityCodes(
                   asList(
@@ -48,7 +54,10 @@ class SwaggerCommunityCareEligibilityResponse {
                                   .zip("10946")
                                   .build())
                           .coordinates(
-                              Coordinates.builder().latitude(41.81).longitude(67.65).build())
+                              Coordinates.builder()
+                                  .latitude(new BigDecimal("41.81"))
+                                  .longitude(new BigDecimal("67.65"))
+                                  .build())
                           .phoneNumber("177-112-8657 x")
                           .website("https://www.va.gov")
                           .build(),
@@ -63,7 +72,10 @@ class SwaggerCommunityCareEligibilityResponse {
                                   .zip("75025")
                                   .build())
                           .coordinates(
-                              Coordinates.builder().latitude(196.418).longitude(317.811).build())
+                              Coordinates.builder()
+                                  .latitude(new BigDecimal("196.418"))
+                                  .longitude(new BigDecimal("317.811"))
+                                  .build())
                           .phoneNumber("1-422-983-2040")
                           .website("https://www.va.gov")
                           .build()))

--- a/community-care-eligibility/pom.xml
+++ b/community-care-eligibility/pom.xml
@@ -11,7 +11,7 @@
   <version>2.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <ee-client.version>2.0.1</ee-client.version>
+    <ee-client.version>2.0.2</ee-client.version>
     <jacoco.coverage>0.86</jacoco.coverage>
   </properties>
   <dependencies>

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
@@ -1,5 +1,6 @@
 package gov.va.api.health.communitycareeligibility.service;
 
+import static gov.va.api.health.communitycareeligibility.service.Transformers.allBlank;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
@@ -155,7 +156,7 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
 
     BigDecimal lat = geocoding.getAddressLatitude();
     BigDecimal lng = geocoding.getAddressLongitude();
-    if (lat == null && lng == null) {
+    if (allBlank(lat, lng)) {
       return null;
     }
 

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
@@ -87,7 +87,7 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
         || eeResponse.getSummary().getDemographics().getContactInfo().getAddresses() == null) {
       throw new Exceptions.MissingResidentialAddressException(patientIcn);
     }
-    Optional<AddressInfo> maybeEeAddress =
+    Optional<AddressInfo> eeAddress =
         eeResponse
             .getSummary()
             .getDemographics()
@@ -97,36 +97,36 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
             .stream()
             .filter(a -> "Residential".equals(a.getAddressTypeCode()))
             .findFirst();
-    if (!maybeEeAddress.isPresent()) {
+    if (!eeAddress.isPresent()) {
       throw new Exceptions.MissingResidentialAddressException(patientIcn);
     }
 
-    AddressInfo eeAddress = maybeEeAddress.get();
+    AddressInfo addressInfo = eeAddress.get();
 
-    String zip = trimToEmpty(eeAddress.getZipCode());
+    String zip = trimToEmpty(addressInfo.getZipCode());
     if (zip.isEmpty()) {
-      if (trimToEmpty(eeAddress.getPostalCode()).isEmpty()) {
-        zip = trimToEmpty(eeAddress.getZipcode());
+      if (trimToEmpty(addressInfo.getPostalCode()).isEmpty()) {
+        zip = trimToEmpty(addressInfo.getZipcode());
       } else {
-        zip = trimToEmpty(eeAddress.getPostalCode());
+        zip = trimToEmpty(addressInfo.getPostalCode());
       }
     }
-    String zipPlus4 = trimToEmpty(eeAddress.getZipPlus4());
+    String zipPlus4 = trimToEmpty(addressInfo.getZipPlus4());
     if (!zip.isEmpty() && !zipPlus4.isEmpty()) {
       zip = zip + "-" + zipPlus4;
     }
 
     Address address =
         Address.builder()
-            .city(trimToEmpty(eeAddress.getCity()))
-            .state(trimToEmpty(eeAddress.getState()).toUpperCase())
+            .city(trimToEmpty(addressInfo.getCity()))
+            .state(trimToEmpty(addressInfo.getState()).toUpperCase())
             .street(
                 trimToEmpty(
-                    trimToEmpty(eeAddress.getLine1())
+                    trimToEmpty(addressInfo.getLine1())
                         + " "
-                        + trimToEmpty(eeAddress.getLine2())
+                        + trimToEmpty(addressInfo.getLine2())
                         + " "
-                        + trimToEmpty(eeAddress.getLine3())))
+                        + trimToEmpty(addressInfo.getLine3())))
             .zip(zip)
             .build();
 

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -18,8 +18,8 @@ final class Exceptions {
   }
 
   static final class IncompleteAddressException extends RuntimeException {
-    IncompleteAddressException(Address patientAddress) {
-      super("Residential address has incomplete information: " + patientAddress);
+    IncompleteAddressException(String patientIcn, Address patientAddress) {
+      super("Residential address for ICN " + patientIcn + " is incomplete: " + patientAddress);
     }
   }
 

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
@@ -3,7 +3,6 @@ package gov.va.api.health.communitycareeligibility.service;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
 import java.util.Collections;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@Slf4j
 @Component
 public class RestFacilitiesClient implements FacilitiesClient {
   private final String vaFacilitiesApiKey;

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/VaFacilitiesResponse.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/VaFacilitiesResponse.java
@@ -3,6 +3,7 @@ package gov.va.api.health.communitycareeligibility.service;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -47,9 +48,9 @@ public final class VaFacilitiesResponse {
   public static final class Attributes {
     private String name;
 
-    private Double lat;
+    private BigDecimal lat;
 
-    private Double lng;
+    private BigDecimal lng;
 
     private Address address;
 

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
@@ -1,9 +1,9 @@
 package gov.va.api.health.communitycareeligibility.service;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.codehaus.groovy.runtime.InvokerHelper.asList;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,9 +18,11 @@ import gov.va.med.esr.webservices.jaxws.schemas.CommunityCareEligibilityInfo;
 import gov.va.med.esr.webservices.jaxws.schemas.ContactInfo;
 import gov.va.med.esr.webservices.jaxws.schemas.DemographicInfo;
 import gov.va.med.esr.webservices.jaxws.schemas.EeSummary;
+import gov.va.med.esr.webservices.jaxws.schemas.GeocodingInfo;
 import gov.va.med.esr.webservices.jaxws.schemas.GetEESummaryResponse;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityCollection;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityInfo;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
@@ -42,7 +44,11 @@ public final class CommunityCareEligibilityTest {
   @Test
   @SneakyThrows
   public void audiology() {
-    Coordinates facilityCoordinates = Coordinates.builder().latitude(200D).longitude(100D).build();
+    Coordinates facilityCoordinates =
+        Coordinates.builder()
+            .latitude(new BigDecimal("200"))
+            .longitude(new BigDecimal("100"))
+            .build();
     Address patientAddress =
         Address.builder().city("Melbourne").state("FL").zip("12345").street("66 Main St").build();
     FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
@@ -55,8 +61,8 @@ public final class CommunityCareEligibilityTest {
                             .id("FAC123")
                             .attributes(
                                 VaFacilitiesResponse.Attributes.builder()
-                                    .lat(200D)
-                                    .lng(100D)
+                                    .lat(new BigDecimal("200"))
+                                    .lng(new BigDecimal("100"))
                                     .address(
                                         VaFacilitiesResponse.Address.builder()
                                             .physical(
@@ -94,6 +100,14 @@ public final class CommunityCareEligibilityTest {
                                                 .build())
                                         .build())
                                 .build())
+                        .communityCareEligibilityInfo(
+                            CommunityCareEligibilityInfo.builder()
+                                .geocodingInfo(
+                                    GeocodingInfo.builder()
+                                        .addressLatitude(new BigDecimal("-50"))
+                                        .addressLongitude(new BigDecimal("50"))
+                                        .build())
+                                .build())
                         .build())
                 .build());
     CommunityCareEligibilityV0ApiController controller =
@@ -118,6 +132,11 @@ public final class CommunityCareEligibilityTest {
                     .city("Melbourne")
                     .zip("12345")
                     .street("66 Main St")
+                    .build())
+            .patientCoordinates(
+                Coordinates.builder()
+                    .latitude(new BigDecimal("-50"))
+                    .longitude(new BigDecimal("50"))
                     .build())
             .eligible(false)
             .eligibilityCodes(emptyList())
@@ -301,8 +320,8 @@ public final class CommunityCareEligibilityTest {
                             .id(" FAC123 ")
                             .attributes(
                                 VaFacilitiesResponse.Attributes.builder()
-                                    .lat(200.00)
-                                    .lng(100.00)
+                                    .lat(new BigDecimal("200.00"))
+                                    .lng(new BigDecimal("100.00"))
                                     .name(" some facility ")
                                     .phone(
                                         VaFacilitiesResponse.Phone.builder()
@@ -578,8 +597,8 @@ public final class CommunityCareEligibilityTest {
                             .id("FAC123")
                             .attributes(
                                 VaFacilitiesResponse.Attributes.builder()
-                                    .lat(200D)
-                                    .lng(100D)
+                                    .lat(new BigDecimal("200"))
+                                    .lng(new BigDecimal("100"))
                                     .address(
                                         VaFacilitiesResponse.Address.builder()
                                             .physical(


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/CCE-132

Update `ee-artifacts` version to expose new `Geocoding` fields from E&E. Consume these fields and add patient latitude and longitude to the response.

These fields will be used in a future story to access the Facilities API `/nearby` endpoint.

Mock-EE does not have patient coordinates, but they are available in the E&E `esrstage1a` environment.

Also includes refactoring to `BigDecimal` in place of `Double`, both in our API response and in the parsing of the Facilities API objects. `BigDecimal` has the same representation as `Double` in JSON, but is less susceptible to weird floating point behavior.