### PR TITLE
CCE-137 Fix Swagger retrieval and HTTPS --> HTTP

### DIFF
--- a/community-care-eligibility/pom.xml
+++ b/community-care-eligibility/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <ee-client.version>2.0.2</ee-client.version>
     <jacoco.coverage>0.86</jacoco.coverage>
-    <lighthouse-keystore.version>1.0.20</lighthouse-keystore.version>
   </properties>
   <dependencies>
     <dependency>
@@ -34,12 +33,6 @@
       <groupId>gov.va.api.health</groupId>
       <artifactId>ee-artifacts</artifactId>
       <version>${ee-client.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>gov.va.dvp</groupId>
-      <artifactId>lighthouse-keystore</artifactId>
-      <version>${lighthouse-keystore.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/community-care-eligibility/pom.xml
+++ b/community-care-eligibility/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <ee-client.version>2.0.2</ee-client.version>
     <jacoco.coverage>0.86</jacoco.coverage>
+    <lighthouse-keystore.version>1.0.20</lighthouse-keystore.version>
   </properties>
   <dependencies>
     <dependency>
@@ -33,6 +34,12 @@
       <groupId>gov.va.api.health</groupId>
       <artifactId>ee-artifacts</artifactId>
       <version>${ee-client.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>gov.va.dvp</groupId>
+      <artifactId>lighthouse-keystore</artifactId>
+      <version>${lighthouse-keystore.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/HomeControllerV0.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/HomeControllerV0.java
@@ -1,13 +1,11 @@
 package gov.va.api.health.communitycareeligibility.service;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/HomeControllerV0.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/HomeControllerV0.java
@@ -1,12 +1,12 @@
 package gov.va.api.health.communitycareeligibility.service;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,13 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class HomeControllerV0 {
   private static final YAMLMapper MAPPER = new YAMLMapper();
 
-  private final Resource openApi;
-
-  @Autowired
-  public HomeControllerV0(@Value("classpath:/openapi.yaml") Resource openapi) {
-    this.openApi = openapi;
-  }
-
   /** REST endpoint for OpenAPI JSON + redirect. */
   @GetMapping(
     value = {"/", "/openapi.json", "/api/openapi.json"},
@@ -33,7 +26,7 @@ public class HomeControllerV0 {
   )
   @ResponseBody
   public Object openApiJson() throws IOException {
-    return HomeControllerV0.MAPPER.readValue(openApiYamlContent(), Object.class);
+    return MAPPER.readValue(openApiYamlContent(), Object.class);
   }
 
   /** REST endpoint OpenAPI YAML. */
@@ -49,7 +42,7 @@ public class HomeControllerV0 {
   /** OpenAPI content in YAML form. */
   @Bean
   private String openApiYamlContent() throws IOException {
-    try (InputStream is = openApi.getInputStream()) {
+    try (InputStream is = new ClassPathResource("openapi.yaml").getInputStream()) {
       return StreamUtils.copyToString(is, Charset.defaultCharset());
     }
   }

--- a/community-care-eligibility/src/main/resources/application.properties
+++ b/community-care-eligibility/src/main/resources/application.properties
@@ -1,13 +1,15 @@
 server.port=8090
-security.require-ssl=true
-server.ssl.key-store-type=JKS
-server.ssl.key-store=unset
-server.ssl.key-store-password=unset
-server.ssl.key-alias=unset
+
+server.ssl.client-auth=none
+ssl.use-trust-store=false
+server.ssl.enabled=false
+ssl.enable-client=false
+
 logging.stack-trace-filter=java.lang.reflect.Method, org.apache.catalina, org.springframework.aop, org.springframework.security, org.springframework.transaction, org.springframework.web, org.springframework.cglib, org.springframework.validation.beanvalidation, reactor.core, reactor.ipc, sun.reflect, net.sf.cglib, ByCGLIB, io.netty
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx{full,${logging.stack-trace-filter}}}
 logging.level.com.zaxxer.hikari.HikariDataSource=WARN
 spring.jackson.default-property-inclusion=non_empty
+
 va-facilities.api-key=unset
 community-care.max-drive-time-min-primary=30
 community-care.max-drive-time-min-specialty=60

--- a/community-care-eligibility/src/main/resources/application.properties
+++ b/community-care-eligibility/src/main/resources/application.properties
@@ -1,15 +1,13 @@
 server.port=8090
-
-server.ssl.client-auth=none
-ssl.use-trust-store=false
-server.ssl.enabled=false
-ssl.enable-client=false
-
+security.require-ssl=true
+server.ssl.key-store-type=JKS
+server.ssl.key-store=unset
+server.ssl.key-store-password=unset
+server.ssl.key-alias=unset
 logging.stack-trace-filter=java.lang.reflect.Method, org.apache.catalina, org.springframework.aop, org.springframework.security, org.springframework.transaction, org.springframework.web, org.springframework.cglib, org.springframework.validation.beanvalidation, reactor.core, reactor.ipc, sun.reflect, net.sf.cglib, ByCGLIB, io.netty
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx{full,${logging.stack-trace-filter}}}
 logging.level.com.zaxxer.hikari.HikariDataSource=WARN
 spring.jackson.default-property-inclusion=non_empty
-
 va-facilities.api-key=unset
 community-care.max-drive-time-min-primary=30
 community-care.max-drive-time-min-specialty=60

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/client/RestFacilitiesClientTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/client/RestFacilitiesClientTest.java
@@ -26,14 +26,14 @@ public final class RestFacilitiesClientTest {
     RestTemplate restTemplate = mock(RestTemplate.class);
     when(restTemplate.exchange(
             eq(
-                "https://foo/bar/v1/nearby?state=FL&city=Melbourne&street_address=123 Main&zip=12345&drive_time=30&type=health&services[]=PrimaryCare&page=1&per_page=500"),
+                "http://foo/bar/v1/nearby?state=FL&city=Melbourne&street_address=123 Main&zip=12345&drive_time=30&type=health&services[]=PrimaryCare&page=1&per_page=500"),
             eq(HttpMethod.GET),
             any(HttpEntity.class),
             eq(VaFacilitiesResponse.class)))
         .thenReturn(response);
 
     RestFacilitiesClient client =
-        new RestFacilitiesClient("fakeApiKey", "https://foo/bar", restTemplate);
+        new RestFacilitiesClient("fakeApiKey", "http://foo/bar", restTemplate);
     assertThat(
             client.nearbyFacilities(
                 CommunityCareEligibilityResponse.Address.builder()

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/client/RestFacilitiesClientTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/client/RestFacilitiesClientTest.java
@@ -26,14 +26,14 @@ public final class RestFacilitiesClientTest {
     RestTemplate restTemplate = mock(RestTemplate.class);
     when(restTemplate.exchange(
             eq(
-                "http://foo/bar/v1/nearby?state=FL&city=Melbourne&street_address=123 Main&zip=12345&drive_time=30&type=health&services[]=PrimaryCare&page=1&per_page=500"),
+                "https://foo/bar/v1/nearby?state=FL&city=Melbourne&street_address=123 Main&zip=12345&drive_time=30&type=health&services[]=PrimaryCare&page=1&per_page=500"),
             eq(HttpMethod.GET),
             any(HttpEntity.class),
             eq(VaFacilitiesResponse.class)))
         .thenReturn(response);
 
     RestFacilitiesClient client =
-        new RestFacilitiesClient("fakeApiKey", "http://foo/bar", restTemplate);
+        new RestFacilitiesClient("fakeApiKey", "https://foo/bar", restTemplate);
     assertThat(
             client.nearbyFacilities(
                 CommunityCareEligibilityResponse.Address.builder()

--- a/configuration.md
+++ b/configuration.md
@@ -60,22 +60,6 @@ va-facilities.url ...........................VA Facilities API URL
 community-care.max-drive-time-min-primary....Max drive time (minutes) criteria for primary care eligibility
 community-care.max-drive-time-min-specialty..Max drive time (minutes) criteria for specialty care eligibility
 
-# Server SSL
-server.ssl.key-store ....................Path to keystore, e.g. /opt/va/certs/<any>.jks
-server.ssl.key-alias ....................Alias for key in keystore
-server.ssl.key-store-password ...........Password for the keystore
-server.ssl.trust-store ..................Path to truststore
-server.ssl.trust-store-password .........Password for the truststore
-server.ssl.enabled ......................<true|false> If enabled, mutual TLS is configured
-
-# Client SSL
-ssl.key-store ...........................Path to keystore to use as a client
-ssl.key-store-password ..................Password for the keystore
-ssl.client-key-password .................Password for the client key
-ssl.use-trust-store .....................<true|false> If enabled, mutual TLS is configured
-ssl.trust-store .........................Path to truststore
-ssl.trust-store-password ................Password for the truststore
-
 #E&E Request Properties
 ee.endpoint.url .........................E&E Endpoint URL
 ee.header.username ......................E&E Username

--- a/configuration.md
+++ b/configuration.md
@@ -60,6 +60,22 @@ va-facilities.url ...........................VA Facilities API URL
 community-care.max-drive-time-min-primary....Max drive time (minutes) criteria for primary care eligibility
 community-care.max-drive-time-min-specialty..Max drive time (minutes) criteria for specialty care eligibility
 
+# Server SSL
+server.ssl.key-store ....................Path to keystore, e.g. /opt/va/certs/<any>.jks
+server.ssl.key-alias ....................Alias for key in keystore
+server.ssl.key-store-password ...........Password for the keystore
+server.ssl.trust-store ..................Path to truststore
+server.ssl.trust-store-password .........Password for the truststore
+server.ssl.enabled ......................<true|false> If enabled, mutual TLS is configured
+
+# Client SSL
+ssl.key-store ...........................Path to keystore to use as a client
+ssl.key-store-password ..................Password for the keystore
+ssl.client-key-password .................Password for the client key
+ssl.use-trust-store .....................<true|false> If enabled, mutual TLS is configured
+ssl.trust-store .........................Path to truststore
+ssl.trust-store-password ................Password for the truststore
+
 #E&E Request Properties
 ee.endpoint.url .........................E&E Endpoint URL
 ee.header.username ......................E&E Username

--- a/src/scripts/make-configs.sh
+++ b/src/scripts/make-configs.sh
@@ -67,24 +67,7 @@ makeConfig() {
   local target="$REPO/$project/config/application-${profile}.properties"
   [ -f "$target" ] && mv -v $target $target.$MARKER
   grep -E '(.*= *unset)' "$REPO/$project/src/main/resources/application.properties" \
-    | grep -Ev '(^server\.ssl\.|^ssl\.)' \
     > "$target"
-cat >> "$target" <<EOF
-# Server SSL
-server.ssl.key-store=file:target/certs/system/DVP-DVP-NONPROD.jks
-server.ssl.key-alias=internal-sys-dev
-server.ssl.key-store-password=$KEYSTORE_PASSWORD
-server.ssl.trust-store=file:target/certs/system/DVP-NONPROD-truststore.jks
-server.ssl.trust-store-password=$KEYSTORE_PASSWORD
-server.ssl.client-auth=want
-# Client SSL
-ssl.key-store=file:target/certs/system/DVP-DVP-NONPROD.jks
-ssl.key-store-password=$KEYSTORE_PASSWORD
-ssl.client-key-password=$KEYSTORE_PASSWORD
-ssl.use-trust-store=true
-ssl.trust-store=file:target/certs/system/DVP-NONPROD-truststore.jks
-ssl.trust-store-password=$KEYSTORE_PASSWORD
-EOF
 }
 
 configValue() {

--- a/src/scripts/make-configs.sh
+++ b/src/scripts/make-configs.sh
@@ -67,7 +67,24 @@ makeConfig() {
   local target="$REPO/$project/config/application-${profile}.properties"
   [ -f "$target" ] && mv -v $target $target.$MARKER
   grep -E '(.*= *unset)' "$REPO/$project/src/main/resources/application.properties" \
+    | grep -Ev '(^server\.ssl\.|^ssl\.)' \
     > "$target"
+cat >> "$target" <<EOF
+# Server SSL
+server.ssl.key-store=file:target/certs/system/DVP-DVP-NONPROD.jks
+server.ssl.key-alias=internal-sys-dev
+server.ssl.key-store-password=$KEYSTORE_PASSWORD
+server.ssl.trust-store=file:target/certs/system/DVP-NONPROD-truststore.jks
+server.ssl.trust-store-password=$KEYSTORE_PASSWORD
+server.ssl.client-auth=want
+# Client SSL
+ssl.key-store=file:target/certs/system/DVP-DVP-NONPROD.jks
+ssl.key-store-password=$KEYSTORE_PASSWORD
+ssl.client-key-password=$KEYSTORE_PASSWORD
+ssl.use-trust-store=true
+ssl.trust-store=file:target/certs/system/DVP-NONPROD-truststore.jks
+ssl.trust-store-password=$KEYSTORE_PASSWORD
+EOF
 }
 
 configValue() {


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/CCE-137

In addition to the above, CCE was also failing to run locally due to an unrelated upgrade of `health-apis-parent`, which removed the `lighthouse-keystore` dependency. Rather than add this dependency back to CCE, this PR follow's data-query's model (https://github.com/department-of-veterans-affairs/health-apis-data-query/pull/227) to configure CCE for local development with HTTP instead of HTTPS.