### PR TITLE
CCE-144 Use lat/long for Facilities nearby

### DIFF
--- a/community-care-eligibility/pom.xml
+++ b/community-care-eligibility/pom.xml
@@ -12,7 +12,7 @@
   <packaging>jar</packaging>
   <properties>
     <ee-client.version>2.0.4</ee-client.version>
-    <jacoco.coverage>0.86</jacoco.coverage>
+    <jacoco.coverage>0.89</jacoco.coverage>
   </properties>
   <dependencies>
     <dependency>

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
@@ -30,7 +30,6 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotBlank;
 import javax.xml.datatype.XMLGregorianCalendar;
-
 import lombok.Builder;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -239,8 +238,7 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
     List<String> codeStrings =
         eligibilityCodes.stream().map(c -> c.code()).collect(Collectors.toList());
     if (CollectionUtils.containsAny(codeStrings, asList("G", "N", "H", "X"))) {
-      // return
-      response
+      return response
           .eligible(!codeStrings.contains("X"))
           .grandfathered(codeStrings.contains("G"))
           .noFullServiceVaMedicalFacility(codeStrings.contains("N"))

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
+import static org.apache.commons.lang3.StringUtils.upperCase;
 
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
@@ -21,6 +22,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -159,7 +161,7 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
 
     return Address.builder()
         .city(trimToNull(addressInfo.getCity()))
-        .state(trimToNull(addressInfo.getState()).toUpperCase())
+        .state(upperCase(trimToNull(addressInfo.getState()), Locale.US))
         .street(
             trimToNull(
                 trimToEmpty(addressInfo.getLine1())
@@ -237,7 +239,8 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
     List<String> codeStrings =
         eligibilityCodes.stream().map(c -> c.code()).collect(Collectors.toList());
     if (CollectionUtils.containsAny(codeStrings, asList("G", "N", "H", "X"))) {
-      return response
+      // return
+      response
           .eligible(!codeStrings.contains("X"))
           .grandfathered(codeStrings.contains("G"))
           .noFullServiceVaMedicalFacility(codeStrings.contains("N"))
@@ -262,7 +265,7 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
         && geocodeXgc
             .toGregorianCalendar()
             .toInstant()
-            .isAfter(eeAddressChangeXgc.toGregorianCalendar().toInstant())) {
+            .isBefore(eeAddressChangeXgc.toGregorianCalendar().toInstant())) {
       throw new Exceptions.OutdatedGeocodingInfoException(
           request.patientIcn(),
           geocodeXgc.toGregorianCalendar().toInstant(),

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityV0ApiController.java
@@ -1,14 +1,17 @@
 package gov.va.api.health.communitycareeligibility.service;
 
-import static gov.va.api.health.communitycareeligibility.service.Transformers.allBlank;
+import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Coordinates;
+import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.EligibilityCode;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Facility;
+import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.PatientRequest;
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityService;
 import gov.va.med.esr.webservices.jaxws.schemas.AddressInfo;
 import gov.va.med.esr.webservices.jaxws.schemas.GeocodingInfo;
@@ -16,8 +19,6 @@ import gov.va.med.esr.webservices.jaxws.schemas.GetEESummaryResponse;
 import gov.va.med.esr.webservices.jaxws.schemas.VceEligibilityInfo;
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,8 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotBlank;
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import lombok.Builder;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +47,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = "/v0/eligibility", produces = "application/json")
 public class CommunityCareEligibilityV0ApiController implements CommunityCareEligibilityService {
+  private static final Map<String, String> SERVICES_MAP = initServicesMap();
+
   private int maxDriveMinsPrimary;
 
   private int maxDriveMinsSpecialty;
@@ -70,12 +75,6 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
             || response.getSummary() == null
             || response.getSummary().getCommunityCareEligibilityInfo() == null
             || response.getSummary().getCommunityCareEligibilityInfo().getEligibilities() == null
-            || response
-                    .getSummary()
-                    .getCommunityCareEligibilityInfo()
-                    .getEligibilities()
-                    .getEligibility()
-                == null
         ? Collections.emptyList()
         : response
             .getSummary()
@@ -84,85 +83,21 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
             .getEligibility();
   }
 
-  private static Address patientAddress(GetEESummaryResponse eeResponse) {
-    if (eeResponse == null
-        || eeResponse.getSummary() == null
-        || eeResponse.getSummary().getDemographics() == null
-        || eeResponse.getSummary().getDemographics().getContactInfo() == null
-        || eeResponse.getSummary().getDemographics().getContactInfo().getAddresses() == null) {
-      return null;
-    }
-
-    Optional<AddressInfo> eeAddress =
-        eeResponse
-            .getSummary()
-            .getDemographics()
-            .getContactInfo()
-            .getAddresses()
-            .getAddress()
-            .stream()
-            .filter(a -> "Residential".equalsIgnoreCase(a.getAddressTypeCode()))
-            .findFirst();
-    if (!eeAddress.isPresent()) {
-      return null;
-    }
-
-    AddressInfo addressInfo = eeAddress.get();
-
-    String zip = trimToEmpty(addressInfo.getZipCode());
-    if (zip.isEmpty()) {
-      if (trimToEmpty(addressInfo.getPostalCode()).isEmpty()) {
-        zip = trimToEmpty(addressInfo.getZipcode());
-      } else {
-        zip = trimToEmpty(addressInfo.getPostalCode());
-      }
-    }
-    String zipPlus4 = trimToEmpty(addressInfo.getZipPlus4());
-    if (!zip.isEmpty() && !zipPlus4.isEmpty()) {
-      zip = zip + "-" + zipPlus4;
-    }
-
-    return Address.builder()
-        .city(trimToEmpty(addressInfo.getCity()))
-        .state(trimToEmpty(addressInfo.getState()).toUpperCase())
-        .street(
-            trimToEmpty(
-                trimToEmpty(addressInfo.getLine1())
-                    + " "
-                    + trimToEmpty(addressInfo.getLine2())
-                    + " "
-                    + trimToEmpty(addressInfo.getLine3())))
-        .zip(zip)
-        .build();
-  }
-
-  private static Coordinates patientCoordinates(
-      String patientIcn, GetEESummaryResponse eeResponse) {
+  private static Optional<GeocodingInfo> geocodingInfo(GetEESummaryResponse eeResponse) {
     if (eeResponse == null
         || eeResponse.getSummary() == null
         || eeResponse.getSummary().getCommunityCareEligibilityInfo() == null) {
-      throw new Exceptions.MissingGeocodingInfoException(patientIcn);
+      return Optional.empty();
     }
 
-    GeocodingInfo geocoding =
-        eeResponse.getSummary().getCommunityCareEligibilityInfo().getGeocodingInfo();
-    if (geocoding == null) {
-      throw new Exceptions.MissingGeocodingInfoException(patientIcn);
-    }
-
-    BigDecimal lat = geocoding.getAddressLatitude();
-    BigDecimal lng = geocoding.getAddressLongitude();
-    if (lat == null || lng == null) {
-      throw new Exceptions.MissingGeocodingInfoException(patientIcn);
-    }
-
-    return Coordinates.builder().latitude(lat).longitude(lng).build();
+    return Optional.ofNullable(
+        eeResponse.getSummary().getCommunityCareEligibilityInfo().getGeocodingInfo());
   }
 
-  private static Map<String, String> servicesMap() {
+  private static Map<String, String> initServicesMap() {
     Map<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     for (String service :
-        Arrays.asList(
+        asList(
             "Audiology",
             "Cardiology",
             "Dermatology",
@@ -180,8 +115,69 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
     return map;
   }
 
-  static String stripNewlines(String str) {
+  private static Optional<AddressInfo> residentialAddress(GetEESummaryResponse eeResponse) {
+    if (eeResponse == null
+        || eeResponse.getSummary() == null
+        || eeResponse.getSummary().getDemographics() == null
+        || eeResponse.getSummary().getDemographics().getContactInfo() == null
+        || eeResponse.getSummary().getDemographics().getContactInfo().getAddresses() == null) {
+      return Optional.empty();
+    }
+
+    return eeResponse
+        .getSummary()
+        .getDemographics()
+        .getContactInfo()
+        .getAddresses()
+        .getAddress()
+        .stream()
+        .filter(a -> "Residential".equalsIgnoreCase(a.getAddressTypeCode()))
+        .findFirst();
+  }
+
+  private static String stripNewlines(String str) {
     return str.replaceAll("[\r\n]", "");
+  }
+
+  private static Address toAddress(Optional<AddressInfo> eeAddress) {
+    if (eeAddress.isEmpty()) {
+      return null;
+    }
+    AddressInfo addressInfo = eeAddress.get();
+
+    String zip = trimToNull(addressInfo.getZipCode());
+    if (zip == null) {
+      zip = trimToNull(addressInfo.getPostalCode());
+    }
+    if (zip == null) {
+      zip = trimToNull(addressInfo.getZipcode());
+    }
+    String zipPlus4 = trimToNull(addressInfo.getZipPlus4());
+    if (zip != null && zipPlus4 != null) {
+      zip = zip + "-" + zipPlus4;
+    }
+
+    return Address.builder()
+        .city(trimToNull(addressInfo.getCity()))
+        .state(trimToNull(addressInfo.getState()).toUpperCase())
+        .street(
+            trimToNull(
+                trimToEmpty(addressInfo.getLine1())
+                    + " "
+                    + trimToEmpty(addressInfo.getLine2())
+                    + " "
+                    + trimToEmpty(addressInfo.getLine3())))
+        .zip(trimToNull(zip))
+        .build();
+  }
+
+  private static Coordinates toCoordinates(String patientIcn, GeocodingInfo geocodingInfo) {
+    BigDecimal lat = geocodingInfo.getAddressLatitude();
+    BigDecimal lng = geocodingInfo.getAddressLongitude();
+    if (lat == null || lng == null) {
+      throw new Exceptions.MissingGeocodingInfoException(patientIcn);
+    }
+    return Coordinates.builder().latitude(lat).longitude(lng).build();
   }
 
   /** Compute community care eligibility. */
@@ -193,20 +189,31 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
       @NotBlank @RequestParam(value = "patient") String patientIcn,
       @NotBlank @RequestParam(value = "serviceType") String serviceType) {
     if (isNotBlank(optSessionIdHeader)) {
+      // Strip newlines for Spotbugs
       log.info(
           "sessionId={}, patient={}, serviceType={}",
           stripNewlines(optSessionIdHeader),
           stripNewlines(patientIcn),
           stripNewlines(serviceType));
     }
-    String mappedServiceType = servicesMap().get(serviceType);
+
+    String mappedServiceType = SERVICES_MAP.get(serviceType.trim());
     if (mappedServiceType == null) {
       throw new Exceptions.UnknownServiceTypeException(serviceType);
     }
 
-    Instant timestamp = Instant.now();
-    GetEESummaryResponse eeResponse = eeClient.requestEligibility(patientIcn.trim());
-    List<CommunityCareEligibilityResponse.EligibilityCode> eligibilityCodes =
+    return search(
+        PatientRequest.builder()
+            .patientIcn(patientIcn.trim())
+            .serviceType(mappedServiceType)
+            .timestamp(Instant.now().toString())
+            .build());
+  }
+
+  private CommunityCareEligibilityResponse search(PatientRequest request) {
+    GetEESummaryResponse eeResponse = eeClient.requestEligibility(request.patientIcn());
+    Instant timestamp = Instant.parse(request.timestamp());
+    List<EligibilityCode> eligibilityCodes =
         eligibilityInfos(eeResponse)
             .stream()
             .filter(Objects::nonNull)
@@ -220,40 +227,53 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
-    List<String> codeString = new ArrayList<>();
-    for (int i = 0; i < eligibilityCodes.size(); i++) {
-      codeString.add(eligibilityCodes.get(i).code());
-    }
-
-    CommunityCareEligibilityResponse communityCareEligibilityResponse =
+    CommunityCareEligibilityResponse.CommunityCareEligibilityResponseBuilder response =
         CommunityCareEligibilityResponse.builder()
-            .patientRequest(
-                CommunityCareEligibilityResponse.PatientRequest.builder()
-                    .serviceType(mappedServiceType)
-                    .patientIcn(patientIcn)
-                    .timestamp(timestamp.toString())
-                    .build())
+            .patientRequest(request)
             .eligibilityCodes(eligibilityCodes)
             .grandfathered(false)
-            .noFullServiceVaMedicalFacility(false)
-            .build();
+            .noFullServiceVaMedicalFacility(false);
 
-    if (CollectionUtils.containsAny(codeString, Arrays.asList("G", "N", "H", "X"))) {
-      return communityCareEligibilityResponse
-          .eligible(!codeString.contains("X"))
-          .grandfathered(codeString.contains("G"))
-          .noFullServiceVaMedicalFacility(codeString.contains("N"));
+    List<String> codeStrings =
+        eligibilityCodes.stream().map(c -> c.code()).collect(Collectors.toList());
+    if (CollectionUtils.containsAny(codeStrings, asList("G", "N", "H", "X"))) {
+      return response
+          .eligible(!codeStrings.contains("X"))
+          .grandfathered(codeStrings.contains("G"))
+          .noFullServiceVaMedicalFacility(codeStrings.contains("N"))
+          .build();
     }
 
-    Address patientAddress = patientAddress(eeResponse);
-    communityCareEligibilityResponse
-        .patientAddress(patientAddress)
-        .patientCoordinates(patientCoordinates(patientIcn, eeResponse));
+    Optional<AddressInfo> eeAddress = residentialAddress(eeResponse);
+    response.patientAddress(toAddress(eeAddress));
 
-    boolean isPrimary = equalsIgnoreCase(mappedServiceType, "primarycare");
-    final int driveMins = isPrimary ? maxDriveMinsPrimary : maxDriveMinsSpecialty;
+    Optional<GeocodingInfo> geocoding = geocodingInfo(eeResponse);
+    if (geocoding.isEmpty()) {
+      throw new Exceptions.MissingGeocodingInfoException(request.patientIcn());
+    }
+    Coordinates patientCoordinates = toCoordinates(request.patientIcn(), geocoding.get());
+    response.patientCoordinates(patientCoordinates);
+
+    XMLGregorianCalendar eeAddressChangeXgc =
+        eeAddress.isPresent() ? eeAddress.get().getAddressChangeDateTime() : null;
+    XMLGregorianCalendar geocodeXgc = geocoding.get().getGeocodeDate();
+    if (eeAddressChangeXgc != null
+        && geocodeXgc != null
+        && geocodeXgc
+            .toGregorianCalendar()
+            .toInstant()
+            .isAfter(eeAddressChangeXgc.toGregorianCalendar().toInstant())) {
+      throw new Exceptions.OutdatedGeocodingInfoException(
+          request.patientIcn(),
+          geocodeXgc.toGregorianCalendar().toInstant(),
+          eeAddressChangeXgc.toGregorianCalendar().toInstant());
+    }
+
+    String serviceType = request.serviceType();
+    final int driveMins =
+        equalsIgnoreCase(serviceType, "primarycare") ? maxDriveMinsPrimary : maxDriveMinsSpecialty;
     VaFacilitiesResponse nearbyResponse =
-        facilitiesClient.nearbyFacilities(patientAddress, driveMins, mappedServiceType);
+        facilitiesClient.nearbyFacilities(patientCoordinates, driveMins, serviceType);
     List<Facility> nearbyFacilities =
         nearbyResponse == null
             ? Collections.emptyList()
@@ -263,15 +283,14 @@ public class CommunityCareEligibilityV0ApiController implements CommunityCareEli
                 .map(
                     vaFacility ->
                         FacilityTransformer.builder()
-                            .serviceType(mappedServiceType)
+                            .serviceType(serviceType)
                             .build()
                             .toFacility(vaFacility))
                 .collect(Collectors.toList());
-    communityCareEligibilityResponse.nearbyFacilities(nearbyFacilities);
-    if (nearbyFacilities.isEmpty()) {
-      return communityCareEligibilityResponse.eligible(true);
-    }
+    response.nearbyFacilities(nearbyFacilities);
 
-    return communityCareEligibilityResponse.eligible(false);
+    response.eligible(nearbyFacilities.isEmpty());
+
+    return response.build();
   }
 }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/EligibilityAndEnrollmentTransformer.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/EligibilityAndEnrollmentTransformer.java
@@ -11,6 +11,7 @@ import lombok.NonNull;
 @Builder
 final class EligibilityAndEnrollmentTransformer {
   @NonNull private final VceEligibilityInfo eligibilityInfo;
+
   @NonNull private final Instant timestamp;
 
   EligibilityCode toEligibility() {
@@ -21,13 +22,15 @@ final class EligibilityAndEnrollmentTransformer {
       return null;
     }
 
-    if (eligibilityInfo
-        .getVceEffectiveDate()
-        .toGregorianCalendar()
-        .toInstant()
-        .isAfter(timestamp)) {
+    if (eligibilityInfo.getVceEffectiveDate() != null
+        && eligibilityInfo
+            .getVceEffectiveDate()
+            .toGregorianCalendar()
+            .toInstant()
+            .isAfter(timestamp)) {
       return null;
     }
+
     return EligibilityCode.builder().code(code).description(description).build();
   }
 }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -1,7 +1,6 @@
 package gov.va.api.health.communitycareeligibility.service;
 
 import java.time.Instant;
-
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -28,7 +27,8 @@ final class Exceptions {
     OutdatedGeocodingInfoException(String patientIcn, Instant geocodeTime, Instant addressTime) {
       super(
           String.format(
-              "For patient ICN %s, geocoding information (updated %s) is out of date against residential address (updated %s)",
+              "For patient ICN %s, geocoding information (updated %s) is"
+                  + " out of date against residential address (updated %s)",
               patientIcn, geocodeTime, addressTime));
     }
   }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.communitycareeligibility.service;
 
+import java.time.Instant;
+
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -17,8 +19,17 @@ final class Exceptions {
   }
 
   static final class MissingGeocodingInfoException extends RuntimeException {
-	  MissingGeocodingInfoException(String patientIcn) {
+    MissingGeocodingInfoException(String patientIcn) {
       super("No geocoding information found for ICN: " + patientIcn);
+    }
+  }
+
+  static final class OutdatedGeocodingInfoException extends RuntimeException {
+    OutdatedGeocodingInfoException(String patientIcn, Instant geocodeTime, Instant addressTime) {
+      super(
+          String.format(
+              "For patient ICN %s, geocoding information (last updated %s) is out of date against residential address (last updated %s)",
+              patientIcn, geocodeTime, addressTime));
     }
   }
 

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -28,7 +28,7 @@ final class Exceptions {
     OutdatedGeocodingInfoException(String patientIcn, Instant geocodeTime, Instant addressTime) {
       super(
           String.format(
-              "For patient ICN %s, geocoding information (last updated %s) is out of date against residential address (last updated %s)",
+              "For patient ICN %s, geocoding information (updated %s) is out of date against residential address (updated %s)",
               patientIcn, geocodeTime, addressTime));
     }
   }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/Exceptions.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.communitycareeligibility.service;
 
-import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -17,15 +16,9 @@ final class Exceptions {
     }
   }
 
-  static final class IncompleteAddressException extends RuntimeException {
-    IncompleteAddressException(String patientIcn, Address patientAddress) {
-      super("Residential address for ICN " + patientIcn + " is incomplete: " + patientAddress);
-    }
-  }
-
-  static final class MissingResidentialAddressException extends RuntimeException {
-    MissingResidentialAddressException(String patientIcn) {
-      super("No residential address found for ICN: " + patientIcn);
+  static final class MissingGeocodingInfoException extends RuntimeException {
+	  MissingGeocodingInfoException(String patientIcn) {
+      super("No geocoding information found for ICN: " + patientIcn);
     }
   }
 

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/FacilitiesClient.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/FacilitiesClient.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.communitycareeligibility.service;
 
-import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
+import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Coordinates;
 
 public interface FacilitiesClient {
-  VaFacilitiesResponse nearbyFacilities(Address address, int driveMins, String serviceType);
+  VaFacilitiesResponse nearbyFacilities(Coordinates coordinates, int driveMins, String serviceType);
 }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
@@ -37,10 +37,6 @@ public class RestFacilitiesClient implements FacilitiesClient {
       Coordinates coordinates, int driveMins, String serviceType) {
     String url =
         UriComponentsBuilder.fromHttpUrl(baseUrl + "v1/nearby")
-            //            .queryParam("state", address.state())
-            //            .queryParam("city", address.city())
-            //            .queryParam("street_address", address.street())
-            //            .queryParam("zip", address.zip())
             .queryParam("lat", coordinates.latitude())
             .queryParam("lng", coordinates.longitude())
             .queryParam("drive_time", driveMins)

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
@@ -1,7 +1,6 @@
 package gov.va.api.health.communitycareeligibility.service;
 
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Coordinates;
-
 import java.util.Collections;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
@@ -1,6 +1,7 @@
 package gov.va.api.health.communitycareeligibility.service;
 
-import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
+import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Coordinates;
+
 import java.util.Collections;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,13 +34,16 @@ public class RestFacilitiesClient implements FacilitiesClient {
 
   @Override
   @SneakyThrows
-  public VaFacilitiesResponse nearbyFacilities(Address address, int driveMins, String serviceType) {
+  public VaFacilitiesResponse nearbyFacilities(
+      Coordinates coordinates, int driveMins, String serviceType) {
     String url =
         UriComponentsBuilder.fromHttpUrl(baseUrl + "v1/nearby")
-            .queryParam("state", address.state())
-            .queryParam("city", address.city())
-            .queryParam("street_address", address.street())
-            .queryParam("zip", address.zip())
+            //            .queryParam("state", address.state())
+            //            .queryParam("city", address.city())
+            //            .queryParam("street_address", address.street())
+            //            .queryParam("zip", address.zip())
+            .queryParam("lat", coordinates.latitude())
+            .queryParam("lng", coordinates.longitude())
             .queryParam("drive_time", driveMins)
             .queryParam("type", "health")
             .queryParam("services[]", serviceType)
@@ -51,11 +55,9 @@ public class RestFacilitiesClient implements FacilitiesClient {
     headers.add("apiKey", vaFacilitiesApiKey);
     headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
     try {
-      VaFacilitiesResponse responseObject =
-          restTemplate
-              .exchange(url, HttpMethod.GET, new HttpEntity<>(headers), VaFacilitiesResponse.class)
-              .getBody();
-      return responseObject;
+      return restTemplate
+          .exchange(url, HttpMethod.GET, new HttpEntity<>(headers), VaFacilitiesResponse.class)
+          .getBody();
     } catch (Exception e) {
       throw new Exceptions.FacilitiesUnavailableException(e);
     }

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/SteelThreadSystemCheck.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/SteelThreadSystemCheck.java
@@ -1,11 +1,9 @@
 package gov.va.api.health.communitycareeligibility.service;
 
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Coordinates;
+import java.math.BigDecimal;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
-import java.math.BigDecimal;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/SteelThreadSystemCheck.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/SteelThreadSystemCheck.java
@@ -1,8 +1,11 @@
 package gov.va.api.health.communitycareeligibility.service;
 
-import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Address;
+import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse.Coordinates;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
@@ -16,18 +19,21 @@ import org.springframework.web.client.ResourceAccessException;
 @Component
 @Slf4j
 public class SteelThreadSystemCheck implements HealthIndicator {
+  private static final Coordinates COORDINATES =
+      Coordinates.builder()
+          .latitude(new BigDecimal("28.112506"))
+          .longitude(new BigDecimal("-80.7000423"))
+          .build();
+
+  private static final int DRIVE_MINS = 60;
+
+  private static final String SERVICE_TYPE = "PrimaryCare";
 
   private final EligibilityAndEnrollmentClient eeClient;
 
   private final FacilitiesClient facilitiesClient;
 
   private final String icn;
-
-  private final Address address;
-
-  private final int driveMinutes;
-
-  private final String serviceType;
 
   private final SteelThreadSystemCheckLedger ledger;
 
@@ -43,15 +49,6 @@ public class SteelThreadSystemCheck implements HealthIndicator {
     this.eeClient = eeClient;
     this.facilitiesClient = facilitiesClient;
     this.icn = icn;
-    this.address =
-        Address.builder()
-            .city("Melbourne")
-            .state("FL")
-            .zip("32934")
-            .street("505 N John Rodes Blvd")
-            .build();
-    this.driveMinutes = 60;
-    this.serviceType = "PrimaryCare";
     this.ledger = ledger;
     this.consecutiveFailureThreshold = consecutiveFailureThreshold;
   }
@@ -92,11 +89,12 @@ public class SteelThreadSystemCheck implements HealthIndicator {
     if ("skip".equals(icn)) {
       return;
     }
+
     log.info("Performing health check.");
+
     try {
       eeClient.requestEligibility(icn);
-      facilitiesClient.nearbyFacilities(address, driveMinutes, serviceType);
-
+      facilitiesClient.nearbyFacilities(COORDINATES, DRIVE_MINS, SERVICE_TYPE);
       ledger.recordSuccess();
     } catch (HttpServerErrorException
         | HttpClientErrorException

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/WebExceptionHandler.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/WebExceptionHandler.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class WebExceptionHandler {
   @ExceptionHandler({
     ConstraintViolationException.class,
-    Exceptions.OutdatedGeocodingInfoException.class,
     Exceptions.UnknownServiceTypeException.class
   })
   @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -29,6 +28,7 @@ public class WebExceptionHandler {
 
   @ExceptionHandler({
     Exceptions.MissingGeocodingInfoException.class,
+    Exceptions.OutdatedGeocodingInfoException.class,
     Exceptions.UnknownPatientIcnException.class
   })
   @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/WebExceptionHandler.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/WebExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class WebExceptionHandler {
   @ExceptionHandler({
     ConstraintViolationException.class,
+    Exceptions.OutdatedGeocodingInfoException.class,
     Exceptions.UnknownServiceTypeException.class
   })
   @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -26,7 +27,10 @@ public class WebExceptionHandler {
     return responseFor(new ErrorResponse.BadRequest(), e);
   }
 
-  @ExceptionHandler({Exceptions.UnknownPatientIcnException.class})
+  @ExceptionHandler({
+    Exceptions.MissingGeocodingInfoException.class,
+    Exceptions.UnknownPatientIcnException.class
+  })
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public ErrorResponse.NotFound handleNotFound(Exception e) {
     return responseFor(new ErrorResponse.NotFound(), e);

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
@@ -33,7 +33,6 @@ import lombok.SneakyThrows;
 import org.junit.Test;
 
 public final class CommunityCareEligibilityTest {
-
   @SneakyThrows
   private static XMLGregorianCalendar parseXmlGregorianCalendar(String timestamp) {
     GregorianCalendar gCal = new GregorianCalendar();
@@ -163,6 +162,14 @@ public final class CommunityCareEligibilityTest {
             GetEESummaryResponse.builder()
                 .summary(
                     EeSummary.builder()
+                        .communityCareEligibilityInfo(
+                            CommunityCareEligibilityInfo.builder()
+                                .geocodingInfo(
+                                    GeocodingInfo.builder()
+                                        .addressLatitude(BigDecimal.ZERO)
+                                        .addressLongitude(BigDecimal.ONE)
+                                        .build())
+                                .build())
                         .demographics(
                             DemographicInfo.builder()
                                 .contactInfo(
@@ -206,6 +213,11 @@ public final class CommunityCareEligibilityTest {
                         .city("Melbourne")
                         .zip("12345")
                         .street("66 Main St")
+                        .build())
+                .patientCoordinates(
+                    Coordinates.builder()
+                        .latitude(BigDecimal.ZERO)
+                        .longitude(BigDecimal.ONE)
                         .build())
                 .eligibilityCodes(emptyList())
                 .grandfathered(false)
@@ -369,8 +381,8 @@ public final class CommunityCareEligibilityTest {
   }
 
   @SneakyThrows
-  @Test(expected = Exceptions.IncompleteAddressException.class)
-  public void missingAddressInfo() {
+  @Test(expected = Exceptions.MissingGeocodingInfoException.class)
+  public void noGeocodingInfoFound() {
     EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
     when(client.requestEligibility("123"))
         .thenReturn(
@@ -386,40 +398,7 @@ public final class CommunityCareEligibilityTest {
                                                 .address(
                                                     asList(
                                                         AddressInfo.builder()
-                                                            .addressTypeCode("Residential")
-                                                            .build()))
-                                                .build())
-                                        .build())
-                                .build())
-                        .build())
-                .build());
-    CommunityCareEligibilityV0ApiController controller =
-        CommunityCareEligibilityV0ApiController.builder()
-            .facilitiesClient(mock(FacilitiesClient.class))
-            .eeClient(client)
-            .build();
-    controller.search("", "123", "PrimaryCare");
-  }
-
-  @SneakyThrows
-  @Test(expected = Exceptions.MissingResidentialAddressException.class)
-  public void noResidentialFound() {
-    EligibilityAndEnrollmentClient client = mock(EligibilityAndEnrollmentClient.class);
-    when(client.requestEligibility("123"))
-        .thenReturn(
-            GetEESummaryResponse.builder()
-                .summary(
-                    EeSummary.builder()
-                        .demographics(
-                            DemographicInfo.builder()
-                                .contactInfo(
-                                    ContactInfo.builder()
-                                        .addresses(
-                                            AddressCollection.builder()
-                                                .address(
-                                                    asList(
-                                                        AddressInfo.builder()
-                                                            .addressTypeCode("NON_RESIDENTIAL")
+                                                            .addressTypeCode("RESIDENTIAL")
                                                             .state("FL")
                                                             .city("Melbourne")
                                                             .line1("66 Main St")
@@ -463,25 +442,10 @@ public final class CommunityCareEligibilityTest {
                                                             "2099-03-27T14:37:48Z"))
                                                     .build()))
                                         .build())
-                                .build())
-                        .demographics(
-                            DemographicInfo.builder()
-                                .contactInfo(
-                                    ContactInfo.builder()
-                                        .addresses(
-                                            AddressCollection.builder()
-                                                .address(
-                                                    asList(
-                                                        AddressInfo.builder()
-                                                            .addressTypeCode("Residential")
-                                                            .state("FL")
-                                                            .city("Melbourne")
-                                                            .line1("66 Main St")
-                                                            .line2("")
-                                                            .line3("")
-                                                            .zipCode("12345")
-                                                            .build()))
-                                                .build())
+                                .geocodingInfo(
+                                    GeocodingInfo.builder()
+                                        .addressLatitude(BigDecimal.ZERO)
+                                        .addressLongitude(BigDecimal.ONE)
                                         .build())
                                 .build())
                         .build())

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/CommunityCareEligibilityTest.java
@@ -43,15 +43,14 @@ public final class CommunityCareEligibilityTest {
   @Test
   @SneakyThrows
   public void audiology() {
-    Coordinates facilityCoordinates =
-        Coordinates.builder()
-            .latitude(new BigDecimal("200"))
-            .longitude(new BigDecimal("100"))
-            .build();
-    Address patientAddress =
-        Address.builder().city("Melbourne").state("FL").zip("12345").street("66 Main St").build();
     FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
-    when(facilitiesClient.nearbyFacilities(patientAddress, 60, "Audiology"))
+    when(facilitiesClient.nearbyFacilities(
+            Coordinates.builder()
+                .latitude(new BigDecimal("28.112506"))
+                .longitude(new BigDecimal("-80.7000423"))
+                .build(),
+            60,
+            "Audiology"))
         .thenReturn(
             VaFacilitiesResponse.builder()
                 .data(
@@ -66,7 +65,7 @@ public final class CommunityCareEligibilityTest {
                                         VaFacilitiesResponse.Address.builder()
                                             .physical(
                                                 VaFacilitiesResponse.PhysicalAddress.builder()
-                                                    .address1("911 derp st")
+                                                    .address1("911 fac st")
                                                     .state("FL")
                                                     .build())
                                             .build())
@@ -89,11 +88,10 @@ public final class CommunityCareEligibilityTest {
                                                     asList(
                                                         AddressInfo.builder()
                                                             .addressTypeCode("Residential")
-                                                            .state("FL")
-                                                            .city("Melbourne")
-                                                            .line1("66 Main St")
-                                                            .line2("")
-                                                            .line3("")
+                                                            .state(" fL")
+                                                            .city("Melbourne ")
+                                                            .line1(" 66 pat St ")
+                                                            .line3("   ")
                                                             .zipCode("12345")
                                                             .build()))
                                                 .build())
@@ -103,8 +101,8 @@ public final class CommunityCareEligibilityTest {
                             CommunityCareEligibilityInfo.builder()
                                 .geocodingInfo(
                                     GeocodingInfo.builder()
-                                        .addressLatitude(new BigDecimal("-50"))
-                                        .addressLongitude(new BigDecimal("50"))
+                                        .addressLatitude(new BigDecimal("28.112506"))
+                                        .addressLongitude(new BigDecimal("-80.7000423"))
                                         .build())
                                 .build())
                         .build())
@@ -130,12 +128,12 @@ public final class CommunityCareEligibilityTest {
                     .state("FL")
                     .city("Melbourne")
                     .zip("12345")
-                    .street("66 Main St")
+                    .street("66 pat St")
                     .build())
             .patientCoordinates(
                 Coordinates.builder()
-                    .latitude(new BigDecimal("-50"))
-                    .longitude(new BigDecimal("50"))
+                    .latitude(new BigDecimal("28.112506"))
+                    .longitude(new BigDecimal("-80.7000423"))
                     .build())
             .eligible(false)
             .eligibilityCodes(emptyList())
@@ -145,9 +143,12 @@ public final class CommunityCareEligibilityTest {
                 singletonList(
                     Facility.builder()
                         .id("FAC123")
-                        .physicalAddress(
-                            Address.builder().street("911 derp st").state("FL").build())
-                        .coordinates(facilityCoordinates)
+                        .physicalAddress(Address.builder().street("911 fac st").state("FL").build())
+                        .coordinates(
+                            Coordinates.builder()
+                                .latitude(new BigDecimal("200"))
+                                .longitude(new BigDecimal("100"))
+                                .build())
                         .build()))
             .build();
     assertThat(actual).isEqualTo(expected);
@@ -183,9 +184,7 @@ public final class CommunityCareEligibilityTest {
                                                             .state("FL")
                                                             .city("Melbourne")
                                                             .line1("66 Main St")
-                                                            .line2("")
-                                                            .line3("")
-                                                            .zipCode("12345")
+                                                            .zipPlus4(" 1234 ")
                                                             .build()))
                                                 .build())
                                         .build())
@@ -208,12 +207,7 @@ public final class CommunityCareEligibilityTest {
                         .serviceType("PrimaryCare")
                         .build())
                 .patientAddress(
-                    Address.builder()
-                        .state("FL")
-                        .city("Melbourne")
-                        .zip("12345")
-                        .street("66 Main St")
-                        .build())
+                    Address.builder().state("FL").city("Melbourne").street("66 Main St").build())
                 .patientCoordinates(
                     Coordinates.builder()
                         .latitude(BigDecimal.ZERO)
@@ -230,19 +224,19 @@ public final class CommunityCareEligibilityTest {
   @SneakyThrows
   public void facilityTransformerNullChecks() {
     FacilityTransformer transformer = FacilityTransformer.builder().serviceType("xyz").build();
-    // facility is null
+
     assertThat(transformer.toFacility(null)).isNull();
-    // top level attributes is null
+
     assertThat(transformer.toFacility(VaFacilitiesResponse.Facility.builder().build()))
         .isEqualTo(Facility.builder().build());
-    // empty attributes
+
     assertThat(
             transformer.toFacility(
                 VaFacilitiesResponse.Facility.builder()
                     .attributes(VaFacilitiesResponse.Attributes.builder().build())
                     .build()))
         .isEqualTo(Facility.builder().build());
-    // empty address
+
     assertThat(
             transformer.toFacility(
                 VaFacilitiesResponse.Facility.builder()
@@ -252,7 +246,7 @@ public final class CommunityCareEligibilityTest {
                             .build())
                     .build()))
         .isEqualTo(Facility.builder().build());
-    // empty physical address
+
     assertThat(
             transformer.toFacility(
                 VaFacilitiesResponse.Facility.builder()
@@ -308,76 +302,40 @@ public final class CommunityCareEligibilityTest {
                                                             .line2("Apt. 602")
                                                             .line3("")
                                                             .zipCode("12345")
-                                                            .zipPlus4("0104")
+                                                            .zipPlus4("6789")
                                                             .build()))
                                                 .build())
                                         .build())
                                 .build())
                         .build())
                 .build());
-    Address patientAddress =
-        Address.builder()
-            .city("Melbourne")
-            .state("FL")
-            .zip("12345-0104")
-            .street("66 Main St Apt. 602")
-            .build();
-    FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
-    when(facilitiesClient.nearbyFacilities(patientAddress, 1, "PrimaryCare"))
-        .thenReturn(
-            VaFacilitiesResponse.builder()
-                .data(
-                    singletonList(
-                        VaFacilitiesResponse.Facility.builder()
-                            .id(" FAC123 ")
-                            .attributes(
-                                VaFacilitiesResponse.Attributes.builder()
-                                    .lat(new BigDecimal("200.00"))
-                                    .lng(new BigDecimal("100.00"))
-                                    .name(" some facility ")
-                                    .phone(
-                                        VaFacilitiesResponse.Phone.builder()
-                                            .main(" 867-5309 ")
-                                            .build())
-                                    .address(
-                                        VaFacilitiesResponse.Address.builder()
-                                            .physical(
-                                                VaFacilitiesResponse.PhysicalAddress.builder()
-                                                    .address1(" 911 derp st ")
-                                                    .city(" Palm Bay ")
-                                                    .state(" FL ")
-                                                    .zip(" 75319 ")
-                                                    .build())
-                                            .build())
-                                    .build())
-                            .build()))
-                .build());
+
     CommunityCareEligibilityV0ApiController controller =
         CommunityCareEligibilityV0ApiController.builder()
-            .facilitiesClient(facilitiesClient)
+            .facilitiesClient(mock(FacilitiesClient.class))
             .maxDriveTimePrimary(1)
             .eeClient(eeClient)
             .build();
     CommunityCareEligibilityResponse actual = controller.search("", "123", "primarycare");
-    CommunityCareEligibilityResponse expected =
-        CommunityCareEligibilityResponse.builder()
-            .patientRequest(
-                (CommunityCareEligibilityResponse.PatientRequest.builder()
-                    .timestamp(actual.patientRequest().timestamp())
-                    .patientIcn("123")
-                    .serviceType("PrimaryCare")
-                    .build()))
-            .grandfathered(false)
-            .noFullServiceVaMedicalFacility(false)
-            .eligible(true)
-            .eligibilityCodes(
-                Collections.singletonList(
-                    CommunityCareEligibilityResponse.EligibilityCode.builder()
-                        .description("Hardship")
-                        .code("H")
-                        .build()))
-            .build();
-    assertThat(actual).isEqualTo(expected);
+    assertThat(actual)
+        .isEqualTo(
+            CommunityCareEligibilityResponse.builder()
+                .patientRequest(
+                    CommunityCareEligibilityResponse.PatientRequest.builder()
+                        .timestamp(actual.patientRequest().timestamp())
+                        .patientIcn("123")
+                        .serviceType("PrimaryCare")
+                        .build())
+                .grandfathered(false)
+                .noFullServiceVaMedicalFacility(false)
+                .eligible(true)
+                .eligibilityCodes(
+                    Collections.singletonList(
+                        CommunityCareEligibilityResponse.EligibilityCode.builder()
+                            .description("Hardship")
+                            .code("H")
+                            .build()))
+                .build());
   }
 
   @SneakyThrows
@@ -403,7 +361,6 @@ public final class CommunityCareEligibilityTest {
                                                             .city("Melbourne")
                                                             .line1("66 Main St")
                                                             .line2("")
-                                                            .line3("")
                                                             .zipCode("12345")
                                                             .build()))
                                                 .build())
@@ -451,7 +408,8 @@ public final class CommunityCareEligibilityTest {
                         .build())
                 .build());
     FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
-    when(facilitiesClient.nearbyFacilities(any(Address.class), any(int.class), any(String.class)))
+    when(facilitiesClient.nearbyFacilities(
+            any(Coordinates.class), any(int.class), any(String.class)))
         .thenReturn(VaFacilitiesResponse.builder().build());
     CommunityCareEligibilityV0ApiController controller =
         CommunityCareEligibilityV0ApiController.builder()
@@ -549,56 +507,31 @@ public final class CommunityCareEligibilityTest {
                                 .build())
                         .build())
                 .build());
-    Address patientAddress =
-        Address.builder().city("Melbourne").state("FL").zip("12345").street("66 Main St").build();
-    FacilitiesClient facilitiesClient = mock(FacilitiesClient.class);
-    when(facilitiesClient.nearbyFacilities(patientAddress, 60, "Optometry"))
-        .thenReturn(
-            VaFacilitiesResponse.builder()
-                .data(
-                    singletonList(
-                        VaFacilitiesResponse.Facility.builder()
-                            .id("FAC123")
-                            .attributes(
-                                VaFacilitiesResponse.Attributes.builder()
-                                    .lat(new BigDecimal("200"))
-                                    .lng(new BigDecimal("100"))
-                                    .address(
-                                        VaFacilitiesResponse.Address.builder()
-                                            .physical(
-                                                VaFacilitiesResponse.PhysicalAddress.builder()
-                                                    .address1("911 derp st")
-                                                    .state("FL")
-                                                    .build())
-                                            .build())
-                                    .build())
-                            .build()))
-                .build());
     CommunityCareEligibilityV0ApiController controller =
         CommunityCareEligibilityV0ApiController.builder()
-            .facilitiesClient(facilitiesClient)
+            .facilitiesClient(mock(FacilitiesClient.class))
             .eeClient(eeClient)
             .maxDriveTimePrimary(60)
             .build();
     CommunityCareEligibilityResponse actual = controller.search("", "123", "optometry");
-    CommunityCareEligibilityResponse expected =
-        CommunityCareEligibilityResponse.builder()
-            .grandfathered(false)
-            .noFullServiceVaMedicalFacility(false)
-            .patientRequest(
-                CommunityCareEligibilityResponse.PatientRequest.builder()
-                    .patientIcn("123")
-                    .timestamp(actual.patientRequest().timestamp())
-                    .serviceType("Optometry")
-                    .build())
-            .eligible(false)
-            .eligibilityCodes(
-                Collections.singletonList(
-                    CommunityCareEligibilityResponse.EligibilityCode.builder()
-                        .description("Ineligible")
-                        .code("X")
-                        .build()))
-            .build();
-    assertThat(actual).isEqualTo(expected);
+    assertThat(actual)
+        .isEqualTo(
+            CommunityCareEligibilityResponse.builder()
+                .grandfathered(false)
+                .noFullServiceVaMedicalFacility(false)
+                .patientRequest(
+                    CommunityCareEligibilityResponse.PatientRequest.builder()
+                        .patientIcn("123")
+                        .timestamp(actual.patientRequest().timestamp())
+                        .serviceType("Optometry")
+                        .build())
+                .eligible(false)
+                .eligibilityCodes(
+                    Collections.singletonList(
+                        CommunityCareEligibilityResponse.EligibilityCode.builder()
+                            .description("Ineligible")
+                            .code("X")
+                            .build()))
+                .build());
   }
 }

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClientTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClientTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.communitycareeligibility.api.CommunityCareEligibilityResponse;
+import java.math.BigDecimal;
 import org.junit.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -24,7 +25,7 @@ public final class RestFacilitiesClientTest {
     RestTemplate restTemplate = mock(RestTemplate.class);
     when(restTemplate.exchange(
             eq(
-                "http://foo/bar/v1/nearby?state=FL&city=Melbourne&street_address=123 Main&zip=12345&drive_time=30&type=health&services[]=PrimaryCare&page=1&per_page=500"),
+                "http://foo/bar/v1/nearby?lat=0&lng=0&drive_time=30&type=health&services[]=PrimaryCare&page=1&per_page=500"),
             eq(HttpMethod.GET),
             any(HttpEntity.class),
             eq(VaFacilitiesResponse.class)))
@@ -34,11 +35,9 @@ public final class RestFacilitiesClientTest {
         new RestFacilitiesClient("fakeApiKey", "http://foo/bar", restTemplate);
     assertThat(
             client.nearbyFacilities(
-                CommunityCareEligibilityResponse.Address.builder()
-                    .state("FL")
-                    .city("Melbourne")
-                    .street("123 Main")
-                    .zip("12345")
+                CommunityCareEligibilityResponse.Coordinates.builder()
+                    .latitude(BigDecimal.ZERO)
+                    .longitude(BigDecimal.ZERO)
                     .build(),
                 30,
                 "PrimaryCare"))


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/CCE-144

Use patient geocoding coordinates for call to facilities `nearby` endpoint. Throw an exception if geocoding information is unavailable or out-of-date compared to the patient's residential address. No longer throw exceptions if patient address is unavailable.

The diff is messy because several methods were renamed and moved around. Other refactoring:
- Replace `servicesMap()` with a constant `SERVICES_MAP` field to avoid recreating the map on each request
- Refactor a second `search` method that accepts a `PatientRequest` object. This separates the input sanitization (logging the session header, mapping the service type, etc.) from the main body of search logic