### PR TITLE
API-258-include-page-size-for-facilities-ids-query

### DIFF
--- a/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
+++ b/community-care-eligibility/src/main/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClient.java
@@ -41,6 +41,8 @@ public class RestFacilitiesClient implements FacilitiesClient {
     String url =
         UriComponentsBuilder.fromHttpUrl(baseUrl + "v0/facilities")
             .queryParam("ids", String.join(",", ids))
+            .queryParam("page", 1)
+            .queryParam("per_page", 500)
             .build()
             .toUriString();
     try {

--- a/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClientTest.java
+++ b/community-care-eligibility/src/test/java/gov/va/api/health/communitycareeligibility/service/RestFacilitiesClientTest.java
@@ -23,7 +23,7 @@ public final class RestFacilitiesClientTest {
     when(response.getBody()).thenReturn(VaFacilitiesResponse.builder().build());
     RestTemplate restTemplate = mock(RestTemplate.class);
     when(restTemplate.exchange(
-            eq("http://foo/bar/v0/facilities?ids=vha_675GD"),
+            eq("http://foo/bar/v0/facilities?ids=vha_675GD&page=1&per_page=500"),
             eq(HttpMethod.GET),
             any(HttpEntity.class),
             eq(VaFacilitiesResponse.class)))

--- a/src/scripts/make-configs.sh
+++ b/src/scripts/make-configs.sh
@@ -97,6 +97,8 @@ makeConfig community-care-eligibility $PROFILE
 configValue community-care-eligibility $PROFILE ee.endpoint.url "http://localhost:9090/v0/ws"
 configValue community-care-eligibility $PROFILE ee.header.password "MockEEPassword"
 configValue community-care-eligibility $PROFILE ee.header.username "MockEEUsername"
+configValue community-care-eligibility $PROFILE ee.keystore.password "unused"
+configValue community-care-eligibility $PROFILE ee.keystore.path "unused"
 configValue community-care-eligibility $PROFILE va-facilities.api-key "$VA_FACILITIES_API_KEY"
 configValue community-care-eligibility $PROFILE va-facilities.url "$VA_FACILITIES_URL"
 


### PR DESCRIPTION
Updated RestFacilitiesClient.java to have 500 items per a single page. Updated unit test to reflect this change. Updated make config script to use 'unused' keystore keywords.