### PR TITLE
Fixes for build and upgrades to Java 16

### DIFF
--- a/community-care-eligibility-api/pom.xml
+++ b/community-care-eligibility-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>8.0.11</version>
+    <version>8.0.20</version>
     <relativePath/>
   </parent>
   <artifactId>community-care-eligibility-api</artifactId>

--- a/community-care-eligibility-mock-services/pom.xml
+++ b/community-care-eligibility-mock-services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>8.0.10</version>
+    <version>8.0.20</version>
     <relativePath/>
   </parent>
   <artifactId>community-care-eligibility-mock-services</artifactId>

--- a/community-care-eligibility-tests/pom.xml
+++ b/community-care-eligibility-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>test-starter</artifactId>
-    <version>8.0.10</version>
+    <version>8.0.20</version>
     <relativePath/>
   </parent>
   <artifactId>community-care-eligibility-tests</artifactId>

--- a/community-care-eligibility-tests/src/main/docker/Dockerfile
+++ b/community-care-eligibility-tests/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM vasdvp/health-apis-dev-tools:mvn-3.6-jdk-14
+FROM vasdvp/health-apis-dev-tools:mvn-3.8-jdk-16
 
 COPY maven/ /sentinel
 RUN chmod 755 /sentinel/*sh

--- a/community-care-eligibility/pom.xml
+++ b/community-care-eligibility/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>8.0.10</version>
+    <version>8.0.20</version>
     <relativePath/>
   </parent>
   <artifactId>community-care-eligibility</artifactId>

--- a/community-care-eligibility/src/main/resources/application.properties
+++ b/community-care-eligibility/src/main/resources/application.properties
@@ -23,3 +23,5 @@ ee.keystore.password=unset
 ee.keystore.path=unset
 
 logging.level.gov.va.api.health.autoconfig.configuration.SecureRestTemplateConfig=OFF
+
+management.endpoints.web.exposure.include=health,info

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>8.0.11</version>
+    <version>8.0.20</version>
   </parent>
   <artifactId>community-care-eligibility-parent</artifactId>
   <version>4.0.1-SNAPSHOT</version>


### PR DESCRIPTION
CCE wouldn't build locally with the 8.0.11 so bumped it up to 8.0.20.  This matches the dependencies Facilities uses and does build locally.  Let me know if it should be something else?

Also includes fixes for Dockerfile and `application.properties`.